### PR TITLE
docs: add AI context structure for assistants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md — ubuteco_api
+
+Instructions for AI assistants working in this repository.
+
+## Stack
+
+- Ruby 4 / Rails 8.1 API-only
+- PostgreSQL, Redis, Sidekiq, Searchkick + OpenSearch, AnyCable
+- Auth: Devise + JWT (`allowlisted_jwts`)
+- Authorization: CanCanCan
+- Money: money-rails (amounts as cents + ISO currency columns)
+
+## Active frontend
+
+**[ubuteco-react](../ubuteco-react)** is the only active UI. Angular `ubuteco_spa` is abandoned — do not port or reference it.
+
+## Before you code
+
+1. Read [docs/plans/README.md](docs/plans/README.md) — pick **one plan**, check status and dependencies.
+2. Read [docs/context/architecture.md](docs/context/architecture.md) for tenant model and request flow.
+3. Read [docs/dev-setup.md](docs/dev-setup.md) for ports and local commands.
+
+## Branching
+
+- **One plan = one branch:** `feature/<plan-slug>` (e.g. `feature/locale-and-currency`).
+- Do not mix unrelated plans on the same branch.
+- Docs-only changes: `docs/<topic>` (e.g. `docs/ai-context`).
+
+## Do not (unless explicitly asked)
+
+- Run `db:migrate`, `db:drop`, or destructive DB commands — ask first; DB may be offline.
+- Commit secrets (`.env`, credentials).
+- Force-push to `master`.
+- Add schema-per-tenant or large refactors outside the active plan scope.
+
+## Conventions
+
+- Tenant logic: `Current.user` / `Current.organization` — see `app/models/current.rb`.
+- Org-owned records: scope by `organization_id`; never trust `organization_id` from client params on create.
+- Errors: JSON array of strings, often `422` with `errors.full_messages`.
+- Specs: RSpec; request specs for API; mirror patterns in `spec/controllers/api/v1/`.
+- After controller/schema changes: update Swagger (`spec/swagger_helper.rb`) when the plan calls for it.
+
+## Key paths
+
+| Area | Path |
+|------|------|
+| Plans | `docs/plans/` |
+| Context | `docs/context/` |
+| ADRs | `docs/decisions/` |
+| Tenant | `app/models/current.rb`, `app/controllers/concerns/set_current_tenant.rb` |
+| Abilities | `app/models/abilities/` |
+| Platform (super admin) | `app/controllers/api/v1/platform/` |
+
+## Companion repo
+
+Frontend plans and UI: [ubuteco-react/docs/plans](../ubuteco-react/docs/plans/README.md)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ High-level view of how the main pieces connect in **local development** (Next.js
 
 **Roadmap / improvement plans:** [docs/plans/README.md](docs/plans/README.md) — multi-tenant through CI/CD, order lifecycle, inventory, users API, and more.
 
+**AI assistants:** [AGENTS.md](AGENTS.md) · [docs/context/](docs/context/) · [docs/dev-setup.md](docs/dev-setup.md)
+
 #### Components
 
 | Component | Role | Default URL / port |

--- a/docs/context/api-conventions.md
+++ b/docs/context/api-conventions.md
@@ -1,0 +1,57 @@
+# API conventions
+
+## Request / response
+
+- JSON API under `/api/v1/`
+- Success: resource JSON or `{ data, meta }` for paginated index (check existing jbuilder for each controller)
+- Validation errors: `422` with JSON array of human-readable strings (often `errors.full_messages`)
+- Delete success: `204 No Content`
+- Auth failure: `401`; forbidden: `403`
+
+## Authentication
+
+```http
+Authorization: Bearer <jwt>
+Content-Type: application/json
+```
+
+Obtain token via Devise session/sign-in endpoints (see routes and swagger).
+
+## Pagination
+
+Index actions use Pagy; search endpoints may use Searchkick — follow existing controller patterns.
+
+## Money fields
+
+Typical pattern on models:
+
+```ruby
+monetize :price_cents, with_currency: :price_currency
+```
+
+In JSON you may see:
+
+- `price_cents` + `price_currency`
+- and/or nested money object from jbuilder `extract!`
+
+Frontend helper: `ubuteco-react/src/app/_lib/money.ts` and `format.ts`.
+
+## Organizations JSON
+
+Partial: `app/views/api/v1/organizations/_organization.json.jbuilder`
+
+Common fields: `id`, `name`, `phone`, `operational_status`, `logo_url`, timestamps. Regional settings (`locale`, `default_currency`, `timezone`) added by plan 02 when migrated.
+
+## File uploads
+
+Active Storage for attachments (e.g. org logo, avatars). URLs may appear as `logo_url`, `avatar_url` in JSON.
+
+## Swagger / contract
+
+- Specs: `spec/requests/api/v1/*_spec.rb` with rswag
+- Schema definitions: `spec/swagger_helper.rb`
+- Regenerate when plan 08 or feature work requires contract sync
+
+## Idempotency / migrations
+
+When adding columns that may already exist from `schema.rb` load (Rails 8 fresh DB), prefer idempotent migrations (`column_exists?`, `index_exists?`) or align `schema.rb` version with migration order — document in plan if non-obvious.

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -1,0 +1,59 @@
+# Architecture — API
+
+Stable reference for how ubuteco_api is structured. For active work items, see [plans/README.md](../plans/README.md).
+
+## Multi-tenant model
+
+**Shared PostgreSQL schema** with `organization_id` on org-owned tables. Not schema-per-tenant.
+
+| Concept | Implementation |
+|---------|----------------|
+| Tenant | `Organization` |
+| Request context | `Current.user`, `Current.organization` (`ActiveSupport::CurrentAttributes`) |
+| Set on each request | `SetCurrentTenant` concern on `ApplicationController` |
+| Authorization | CanCanCan abilities under `app/models/abilities/` |
+| Search | Searchkick + org filters via `SearchkickAuthorizable` |
+| Real-time | AnyCable streams keyed by org (e.g. kitchen) |
+
+Jobs and console **must** set `Current` explicitly or pass `organization_id` — there is no automatic tenant in Sidekiq.
+
+## API surface
+
+- Base path: `/api/v1/`
+- Auth: `Authorization: Bearer <JWT>` (Devise JWT)
+- Platform (cross-org, super admin): `/api/v1/platform/...`
+- Org-scoped resources: `/api/v1/organizations`, `/api/v1/orders`, menu entities, etc.
+
+## Roles (summary)
+
+| Role | Scope |
+|------|--------|
+| `SUPER_ADMIN` | Platform; read catalog cross-org; limited mutation |
+| `ADMIN` | Full org admin |
+| `KITCHEN` | Kitchen queue |
+| `WAITER` | Orders / floor |
+| `CASH_REGISTER` | Register operations |
+| `CUSTOMER` | End customer (limited) |
+
+Details: [roles-and-access.md](./roles-and-access.md)
+
+## Money
+
+- money-rails: `*_cents` integer columns + `*_currency` string (ISO 4217)
+- Default currency in DB is often `BRL` at column level; org-level default currency is planned in [02-locale-and-currency](../plans/02-locale-and-currency.md)
+- JSON: jbuilder may expose cents fields and/or serialized money objects — see [api-conventions.md](./api-conventions.md)
+
+## Key files
+
+```
+app/models/current.rb
+app/controllers/concerns/set_current_tenant.rb
+app/controllers/application_controller.rb
+app/models/abilities/
+config/routes.rb
+```
+
+## Related decisions
+
+- [001-shared-schema-multi-tenant.md](../decisions/001-shared-schema-multi-tenant.md)
+- [003-react-only-frontend.md](../decisions/003-react-only-frontend.md)

--- a/docs/context/roles-and-access.md
+++ b/docs/context/roles-and-access.md
@@ -1,0 +1,50 @@
+# Roles and access — API
+
+CanCanCan abilities are the source of truth. This doc helps humans and AI predict behavior — always verify in `app/models/abilities/`.
+
+## Role names
+
+Stored on `users.role_id` → `roles.name`:
+
+- `SUPER_ADMIN`
+- `ADMIN`
+- `KITCHEN`
+- `WAITER`
+- `CASH_REGISTER`
+- `CUSTOMER`
+
+## Tenant rules
+
+- Org-scoped roles must have `user.organization_id` set.
+- Abilities typically use `user.organization_id` to scope reads/writes.
+- **Never** accept client-supplied `organization_id` for create on tenant-owned records when `Current.organization` should define the tenant (see multi-tenant plan).
+
+## SUPER_ADMIN
+
+- Platform routes under `Api::V1::Platform::*`
+- Can list/view organizations and cross-org data where abilities allow
+- Operational catalog mutation is restricted (read-only platform mode for menu entities)
+
+## ADMIN
+
+- Manage organization settings, users in org, full menu and orders
+- Can update `operational_status` (kitchen open/closed) and org profile fields permitted in controller
+
+## KITCHEN / WAITER / CASH_REGISTER
+
+- Operational roles scoped to their organization
+- Kitchen: queue read/update when org is `open`
+- Operational status toggle: permitted for these roles + admin (see kitchen ability)
+
+## CUSTOMER
+
+- Limited self-service / ordering capabilities per product rules
+
+## Testing access
+
+- Request specs with `auth_header(user)` factory helpers
+- Cross-tenant specs: user from org A must not access org B records by ID
+
+## Frontend mirror
+
+React guards in `ubuteco-react/src/app/_lib/auth-roles.ts` and `AuthGuard` — UX only, not security.

--- a/docs/decisions/001-shared-schema-multi-tenant.md
+++ b/docs/decisions/001-shared-schema-multi-tenant.md
@@ -1,0 +1,26 @@
+# ADR 001: Shared-schema multi-tenant
+
+**Status:** Accepted  
+**Date:** 2026 (documented from plan 01)
+
+## Context
+
+uButeco serves many restaurant organizations. We need tenant isolation, super-admin platform access, and compatibility with Searchkick, Sidekiq, and AnyCable.
+
+## Decision
+
+Use **one PostgreSQL schema** with `organization_id` on tenant-owned tables, plus request-scoped `Current.organization` / `Current.user`.
+
+Do **not** use schema-per-tenant (e.g. Apartment) in the initial architecture.
+
+## Consequences
+
+- Migrations and CI stay standard Rails.
+- Abilities and explicit query scoping are required — no reliance on `default_scope` alone.
+- Cross-tenant IDOR must be prevented in controllers (do not trust param `organization_id` on create).
+- Stronger DB isolation (RLS) can be added later without changing the tenant column model.
+
+## References
+
+- [docs/plans/01-multi-tenant.md](../plans/01-multi-tenant.md)
+- `app/models/current.rb`

--- a/docs/decisions/002-org-locale-not-user-locale.md
+++ b/docs/decisions/002-org-locale-not-user-locale.md
@@ -1,0 +1,25 @@
+# ADR 002: Organization-level locale (v1)
+
+**Status:** Accepted  
+**Date:** 2026 (documented from plan 02)
+
+## Context
+
+Restaurants need consistent money and date formatting. Users asked whether locale/currency/timezone should be per-user or per-organization.
+
+## Decision
+
+**Organization** is the source of truth for `locale`, `default_currency`, and `timezone` in v1.
+
+- UI strings may stay single-language until a later i18n pass (`next-intl` optional in plan 02 phase 4).
+- API error messages use Rails I18n; per-request locale switching is a separate phase.
+
+## Consequences
+
+- All staff in an org see the same formatting.
+- Changing currency affects **new** products/orders only; historical orders keep snapshotted currency columns.
+- Settings UI is **admin-only**.
+
+## References
+
+- [docs/plans/02-locale-and-currency.md](../plans/02-locale-and-currency.md)

--- a/docs/decisions/003-react-only-frontend.md
+++ b/docs/decisions/003-react-only-frontend.md
@@ -1,0 +1,24 @@
+# ADR 003: React-only active frontend
+
+**Status:** Accepted  
+**Date:** 2026
+
+## Context
+
+uButeco had an Angular SPA (`ubuteco_spa`) and a newer Next.js app (`ubuteco-react`).
+
+## Decision
+
+- **All new features and fixes** go to `ubuteco-react` only.
+- `ubuteco_spa` is **abandoned** — no migration, no feature parity effort.
+- Org theme/color customizer (Angular-era) is removed; replaced by user-level dark mode.
+
+## Consequences
+
+- API plans may include a React companion doc under `ubuteco-react/docs/plans/`.
+- Do not block API work on Angular updates.
+- Documentation and AI context should not reference SPA patterns.
+
+## References
+
+- [ubuteco-react README.md](../../../ubuteco-react/README.md)

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,75 @@
+# Development setup — ubuteco_api
+
+## Prerequisites
+
+- Ruby (see `.ruby-version`), Bundler
+- Docker Compose for infrastructure (PostgreSQL, Redis, OpenSearch, AnyCable, Mailcatcher)
+- Sibling checkout: [ubuteco-react](../ubuteco-react)
+
+Full architecture diagram: [README.md](../README.md#system-architecture).
+
+## Default ports
+
+| Service | Port | URL |
+|---------|------|-----|
+| Rails API (Puma) | 3000 | `http://localhost:3000` |
+| PostgreSQL | 5432 | — |
+| Redis | 6379 | — |
+| OpenSearch | 9200 | `http://localhost:9200` |
+| anycable-go (WebSocket) | 8080 | `ws://localhost:8080/api/cable` |
+| Next.js (sibling repo) | 3001* | `http://localhost:3001` |
+
+\*React may use another port if 3001 is busy (`PORT=4000 npm run dev`). Check terminal output.
+
+## Typical flow
+
+```bash
+# 1. Infrastructure (from ubuteco_api)
+docker compose up -d
+
+# 2. API
+cd ubuteco_api
+cp .env-example .env   # if needed
+bundle install
+bin/rails db:create db:migrate
+bin/rails s            # :3000
+
+# 3. Background jobs (separate terminal)
+bundle exec sidekiq
+
+# 4. React (separate terminal)
+cd ../ubuteco-react
+npm install
+npm run dev
+```
+
+## Environment
+
+Copy `.env-example` → `.env`. Common variables:
+
+- `DB_HOST`, `DB_USERNAME`, `DB_PASSWORD` — PostgreSQL
+- Redis / OpenSearch URLs (see `.env-example`)
+
+React `.env` must point API and cable to your machine IP or localhost:
+
+```
+API_URL=http://localhost:3000/api
+CABLE_URL=ws://localhost:8080/api/cable
+```
+
+## Database
+
+- **Do not run migrations** when the user says the database is offline or they are working on another project.
+- Fresh DB: `bin/rails db:drop db:create db:migrate` (Rails 8 may load `schema.rb` for versions already in the file — see plan notes if migrations conflict).
+- Test DB: `RAILS_ENV=test bin/rails db:test:prepare`
+
+## Tests
+
+```bash
+bundle exec rspec
+bundle exec rspec spec/path/to_spec.rb
+```
+
+## Swagger
+
+Generated from rswag specs. After API contract changes, regenerate when the plan requires it (see plan 08).

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -2,6 +2,8 @@
 
 Structured plans for uButeco API (`ubuteco_api`). Each document is self-contained: goals, current state, phases, acceptance criteria, and links to the React companion when the front is involved.
 
+**AI assistants:** read [AGENTS.md](../../AGENTS.md) first, then [docs/context/](../context/) for stable architecture. New plans: copy [TEMPLATE.md](./TEMPLATE.md).
+
 **Active frontend:** [ubuteco-react](../../../ubuteco-react) only. Angular `ubuteco_spa` is abandoned — no SPA migration or parity plans.
 
 **Multi-tenant decision (approved):** shared PostgreSQL schema + `organization_id` + `Current` — not schema-per-tenant. See [01-multi-tenant.md](./01-multi-tenant.md#architecture-decision-approved).
@@ -25,4 +27,12 @@ Frontend companions: [ubuteco-react/docs/plans](../../../ubuteco-react/docs/plan
 
 **Status legend:** `[ ]` not started · `[~]` in progress · `[x]` done
 
-When starting a plan, update its header `Status:` and check boxes as you go.
+When starting a plan, update its header `Status:` and check boxes as you go. Use branch `feature/<plan-slug>` (one plan per branch).
+
+## Also see
+
+| Doc | Purpose |
+|-----|---------|
+| [context/](../context/) | Architecture, roles, API conventions |
+| [decisions/](../decisions/) | ADRs (permanent decisions) |
+| [dev-setup.md](../dev-setup.md) | Ports, docker, migrations |

--- a/docs/plans/TEMPLATE.md
+++ b/docs/plans/TEMPLATE.md
@@ -1,0 +1,74 @@
+# Plan template
+
+Copy this file when adding a new plan. Name: `NN-short-slug.md` (same number in API and React when paired).
+
+```markdown
+# Plan: <Title>
+
+**Status:** not started  
+**Project:** ubuteco_api | ubuteco-react  
+**Companion:** [link to other repo plan if any]  
+**Branch:** `feature/<slug>`  
+**Priority:** P0 | P1 | P2  
+**Depends on:** [other plans]  
+**Estimated effort:** N sprint(s)
+
+---
+
+## Goal
+
+One paragraph: what problem this solves.
+
+---
+
+## Product decisions (lock before coding)
+
+| Decision | Choice |
+|----------|--------|
+| … | … |
+
+---
+
+## Out of scope
+
+- …
+
+---
+
+## Phase 1 — …
+
+- [ ] Task
+- [ ] Task
+
+**Acceptance:** …
+
+---
+
+## Manual steps
+
+- [ ] `bin/rails db:migrate` (when DB available)
+- [ ] …
+
+---
+
+## Definition of done
+
+- [ ] …
+
+---
+
+## References
+
+- Code paths, ADRs, external docs
+```
+
+## Status legend
+
+- Header `Status:` — `not started` · `in progress` · `done`
+- Checkboxes — `[ ]` todo · `[~]` partial · `[x]` complete
+
+## Rules
+
+1. One plan → one git branch (`feature/<slug>`).
+2. Update checkboxes as you work; keep companion plan in sync.
+3. Put **manual** steps (migrations, deploy) in their own section — AI should not run them unless asked.


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with stack, branching rules, and conventions for AI-assisted development
- Add stable reference docs under `docs/context/` (architecture, roles, API conventions)
- Add ADRs under `docs/decisions/` for multi-tenant, org locale, and React-only frontend
- Add `docs/dev-setup.md` and a plan `TEMPLATE.md`; link everything from `docs/plans/README.md`

## Test plan
- [ ] Review `AGENTS.md` reads correctly in GitHub
- [ ] Verify links between plans, context, and companion React repo paths
- [ ] Confirm no code/runtime changes (docs only)


Made with [Cursor](https://cursor.com)