### PR TITLE
fix(views): absolute jbuilder paths for platform organization renders

### DIFF
--- a/app/views/api/v1/organizations/index.json.jbuilder
+++ b/app/views/api/v1/organizations/index.json.jbuilder
@@ -2,7 +2,7 @@
 
 json.data do
   json.array! @records do |organization|
-    json.partial! 'organization', organization: organization
+    json.partial! 'api/v1/organizations/organization', organization: organization
   end
 end
 

--- a/app/views/api/v1/organizations/show.json.jbuilder
+++ b/app/views/api/v1/organizations/show.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.partial! 'organization', organization: @organization
+json.partial! 'api/v1/organizations/organization', organization: @organization

--- a/app/views/api/v1/organizations/users/index.json.jbuilder
+++ b/app/views/api/v1/organizations/users/index.json.jbuilder
@@ -2,7 +2,7 @@
 
 json.data do
   json.array! @records do |user|
-    json.partial! 'user', user: user
+    json.partial! 'api/v1/organizations/users/user', user: user
   end
 end
 


### PR DESCRIPTION
## Summary

- Fix 500 on `GET /api/v1/platform/organizations` (and show/users) caused by Jbuilder resolving partials under `api/v1/platform/organizations/` instead of the shared organization views.
- Use absolute partial paths in organization index/show and organization users index templates.

## Test plan

- [ ] As super admin, `GET /api/v1/platform/organizations` returns 200 with org list
- [ ] `GET /api/v1/platform/organizations/:id` returns organization JSON
- [ ] Org-scoped `GET /api/v1/organizations` still works for ADMIN


Made with [Cursor](https://cursor.com)