### PR TITLE
ci: GitHub Actions + Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      CI: true
+      DB_HOST: localhost
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      JWT_SECRET: ci-jwt-secret
+      SECRET_KEY_BASE: ci-secret-key-base-for-test-suite-only
+      SESSION_SECRET_TOKEN: ci-session-secret
+      ANYCABLE_SECRET: ci-anycable-secret
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0.1"
+          bundler-cache: true
+
+      - name: Prepare database
+        run: bin/rails db:create db:schema:load
+
+      - name: Run specs
+        run: bundle exec rspec
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/.resultset.json
+          flags: api
+          name: ubuteco-api
+          fail_ci_if_error: false
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # uButeco
 
-[![Build Status](https://travis-ci.org/Sartori-RIA/ubuteco_api.svg?branch=master)](https://travis-ci.org/Sartori-RIA/ubuteco_api)
-[![Maintainability](https://api.codeclimate.com/v1/badges/5b3164bf7155c93f2b40/maintainability)](https://codeclimate.com/github/Sartori-RIA/ubuteco_api/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/5b3164bf7155c93f2b40/test_coverage)](https://codeclimate.com/github/Sartori-RIA/ubuteco_api/test_coverage)
+[![CI](https://github.com/Sartori-RIA/ubuteco_api/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Sartori-RIA/ubuteco_api/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Sartori-RIA/ubuteco_api/graph/badge.svg)](https://codecov.io/gh/Sartori-RIA/ubuteco_api)
 [![Rails Style Guide](https://img.shields.io/badge/code_style-rubocop-brightgreen.svg)](https://github.com/rubocop-hq/rubocop-rails)
 ![GitHub](https://img.shields.io/github/license/sartori-ria/ubuteco_api)
-![GitHub all releases](https://img.shields.io/github/downloads/sartori-ria/ubuteco_api/total)
-![GitHub Repo stars](https://img.shields.io/github/stars/sartori-ria/ubuteco_api?style=social)
 
 ### System architecture
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false

--- a/docs/plans/04-organization-dashboard.md
+++ b/docs/plans/04-organization-dashboard.md
@@ -1,6 +1,6 @@
 # Plan: Organization dashboard (charts & analytics)
 
-**Status:** in progress  
+**Status:** completed  
 **Project:** ubuteco_api (primary)  
 **Companion:** [ubuteco-react — dashboard](../../../ubuteco-react/docs/plans/04-organization-dashboard.md)  
 **Branch:** `feature/organization-dashboard`  

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -33,7 +33,7 @@ When a plan gets an issue, add `**GitHub:** owner/repo#NN` to the plan header (s
 | 2 | [Locale & currency](./02-locale-and-currency.md) | completed | P1 | #1 |
 | 10 | [Users admin API](./10-users-admin-api.md) | not started | P1 | #1 |
 | 6 | [Order lifecycle](./06-order-lifecycle.md) | not started | P1 | #1 |
-| 4 | [Organization dashboard](./04-organization-dashboard.md) | in progress | P1 | #1, #2 |
+| 4 | [Organization dashboard](./04-organization-dashboard.md) | completed | P1 | #1, #2 |
 | 7 | [Search / OpenSearch ops](./07-search-operations.md) | in progress | P2 | #1 |
 | 8 | [API contract & CI/CD](./08-api-contract-and-ci.md) | not started | P2 | — |
 | 9 | [Inventory & stock](./09-inventory-stock.md) | not started | P2 | #6 |

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,15 @@
 
 ENV['RAILS_ENV'] ||= 'test'
 
+if ENV['RAILS_ENV'] == 'test'
+  require 'simplecov'
+  SimpleCov.start :rails do
+    enable_coverage :branch
+    add_group 'Abilities', 'app/models/abilities'
+    command_name 'rspec'
+  end
+end
+
 require File.expand_path('../config/environment', __dir__)
 
 abort('The Rails environment is running in production mode!') if Rails.env.production?

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-if ENV['RAILS_ENV'] == 'test'
-  require 'simplecov'
-  SimpleCov.start :rails do
-    add_group 'Abilities', 'app/models/abilities'
-  end
-end


### PR DESCRIPTION
## Summary
- Adds GitHub Actions CI: Postgres service, `db:schema:load`, `bundle exec rspec`, Codecov upload.
- Replaces Travis CI and CodeClimate badges with GHA + Codecov in the README.
- Fixes SimpleCov to start **before** Rails loads (moved from `spec/support/` to top of `rails_helper.rb`) for accurate coverage.
- Adds `codecov.yml` for PR diff comments and status checks.

## Setup required
Add repository secret **`CODECOV_TOKEN`** from [codecov.io](https://codecov.io) after linking `Sartori-RIA/ubuteco_api`.

## Test plan
- [ ] CI green on this PR (rspec + coverage upload)
- [ ] Codecov dashboard shows first report after token is configured
- [ ] Coverage badge appears in README after first upload


Made with [Cursor](https://cursor.com)