### PR TITLE
feat: order lifecycle — AASM, services, kitchen guards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :test do
   gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'simplecov-console'
+  gem 'simplecov-cobertura'
   gem 'rspec-sidekiq'
   gem 'database_cleaner-active_record'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '4.0.1'
 
+gem 'aasm', '~> 5.5'
 gem 'bootsnap', '~> 1.23', require: false
 gem 'cancancan', '~> 3.6', '>= 3.6.1'
 gem 'devise', '~> 5.0', '>= 5.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -580,6 +580,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (3.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-console (0.9.5)
       ansi
       simplecov
@@ -681,6 +684,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq (~> 8.1)
   simplecov
+  simplecov-cobertura
   simplecov-console
   tzinfo-data
 
@@ -893,6 +897,7 @@ CHECKSUMS
   shoulda-matchers (7.0.1) sha256=b4bfd8744c10e0a36c8ac1a687f921ee7e25ed529e50488d61b79a8688749c77
   sidekiq (8.1.0) sha256=6bde5eaee9e4d7b1121e97ebd585273627fb32b1f870a47893723572479ad1e4
   simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+  simplecov-cobertura (3.1.0) sha256=6d7f38aa32c965ca2174b2e5bd88cb17138eaf629518854976ac50e628925dc5
   simplecov-console (0.9.5) sha256=b1108bcfff5f210143e2b8301698c367b01586f20d25a73e95475a5df6fc6ff6
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.5.2)
+      concurrent-ruby (~> 1.0)
     action_text-trix (2.1.19)
       railties
     actioncable (8.1.3)
@@ -630,6 +632,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  aasm (~> 5.5)
   anycable-rails (~> 1.6)
   bootsnap (~> 1.23)
   brakeman
@@ -682,6 +685,7 @@ DEPENDENCIES
   tzinfo-data
 
 CHECKSUMS
+  aasm (5.5.2) sha256=a3b874b33d9cbb3be4a2c77185c340a07fb46d7cd31911cbc49337e31d12612f
   action_text-trix (2.1.19) sha256=7012f59421009cf284aa651294896414d653a61a2417c9b8714c8476d2f74009
   actioncable (8.1.3) sha256=e5bc7f75e44e6a22de29c4f43176927c3a9ce4824464b74ed18d8226e75a80f0
   actionmailbox (8.1.3) sha256=df7da474eaa0e70df4ed5a6fef66eb3b3b0f2dbf7f14518deee8d77f1b4aae59

--- a/app/controllers/api/v1/kitchens_controller.rb
+++ b/app/controllers/api/v1/kitchens_controller.rb
@@ -32,15 +32,19 @@ module Api
           return head :forbidden
         end
 
-        if organization.closed?
-          return render json: ['Kitchen is closed'], status: :forbidden
-        end
+        @kitchen = ::Kitchen::UpdateItemStatus.call(
+          order_item: @kitchen,
+          status: update_params[:status],
+          organization:
+        )
 
-        if @kitchen.update(update_params)
-          render :show, status: :ok
-        else
+        if @kitchen.errors.any?
           render json: @kitchen.errors.full_messages, status: :unprocessable_content
+        else
+          render :show, status: :ok
         end
+      rescue Kitchen::UpdateItemStatus::KitchenClosed
+        render json: ["Kitchen is closed"], status: :forbidden
       end
 
       protected

--- a/app/controllers/api/v1/orders/items_controller.rb
+++ b/app/controllers/api/v1/orders/items_controller.rb
@@ -30,27 +30,18 @@ module Api
         end
 
         def update
-          previous_quantity = @item.quantity
+          @item = ::Orders::UpdateItem.call(order_item: @item, params: update_params)
 
-          OrderItem.transaction do
-            unless @item.update(update_params)
-              render_model_errors(@item)
-              raise ActiveRecord::Rollback
-            end
-
-            @item.apply_quantity_change!(previous_quantity:)
+          if @item.errors.empty?
+            @item = OrderItem.includes(:item).find(@item.id)
+            render :show, status: :ok
+          else
+            render_model_errors(@item)
           end
-
-          return if performed?
-
-          @item = OrderItem.includes(:item).find(@item.id)
-          render :show, status: :ok
-        rescue OrderItem::InsufficientStock
-          render_api_errors([{ code: "insufficient_stock", message: "Insufficient stock" }])
         end
 
         def destroy
-          if @item.destroy
+          if ::Orders::RemoveItem.call(order_item: @item)
             head :no_content
           else
             render_model_errors(@item)

--- a/app/controllers/api/v1/orders/items_controller.rb
+++ b/app/controllers/api/v1/orders/items_controller.rb
@@ -17,9 +17,9 @@ module Api
 
         def create
           authorize! :create, OrderItem.new(order: @order)
-          @item = @order.order_items.build(create_params)
+          @item = ::Orders::AddItem.call(order: @order, params: create_params)
 
-          if @item.save
+          if @item.persisted?
             @item = OrderItem.includes(:item).find(@item.id)
             render :show, status: :created
           else

--- a/app/models/concerns/order_item_state_machine.rb
+++ b/app/models/concerns/order_item_state_machine.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module OrderItemStateMachine
+  extend ActiveSupport::Concern
+
+  DISH_TRANSITIONS = {
+    awaiting: %i[cooking canceled],
+    cooking: %i[ready canceled],
+    ready: %i[with_the_client canceled],
+    with_the_client: [],
+    canceled: [],
+    empty_stock: []
+  }.freeze
+
+  NON_DISH_TRANSITIONS = {
+    awaiting: %i[with_the_client canceled empty_stock],
+    with_the_client: [],
+    canceled: [],
+    empty_stock: [],
+    cooking: [],
+    ready: []
+  }.freeze
+
+  included do
+    include AASM
+
+    aasm column: :status, enum: true do
+      state :awaiting, initial: true
+      state :cooking, :ready, :with_the_client, :canceled, :empty_stock
+
+      event :start_cooking do
+        transitions from: :awaiting, to: :cooking
+      end
+
+      event :mark_ready do
+        transitions from: :cooking, to: :ready
+      end
+
+      event :serve do
+        transitions from: :ready, to: :with_the_client
+      end
+
+      event :cancel do
+        transitions from: %i[awaiting cooking ready], to: :canceled
+      end
+
+      event :mark_empty_stock do
+        transitions from: :awaiting, to: :empty_stock
+      end
+    end
+
+    validate :status_transition_must_be_allowed, if: :validate_status_transition?
+  end
+
+  private
+
+  def validate_status_transition?
+    will_save_change_to_status? && !new_record?
+  end
+
+  def status_transition_must_be_allowed
+    from = status_was.to_sym
+    to = status.to_sym
+    return if from == to
+
+    allowed = dish? ? DISH_TRANSITIONS[from] : NON_DISH_TRANSITIONS[from]
+    return if allowed&.include?(to)
+
+    errors.add(:status, "cannot transition from #{from} to #{to}")
+  end
+end

--- a/app/models/concerns/order_item_state_machine.rb
+++ b/app/models/concerns/order_item_state_machine.rb
@@ -59,8 +59,9 @@ module OrderItemStateMachine
   end
 
   def status_transition_must_be_allowed
-    from = status_was.to_sym
-    to = status.to_sym
+    from = status_was&.to_sym
+    to = status&.to_sym
+    return if to.nil?
     return if from == to
 
     allowed = dish? ? DISH_TRANSITIONS[from] : NON_DISH_TRANSITIONS[from]

--- a/app/models/concerns/order_state_machine.rb
+++ b/app/models/concerns/order_state_machine.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module OrderStateMachine
+  extend ActiveSupport::Concern
+
+  PERMITTED_TRANSITIONS = {
+    "open" => %w[closed payed],
+    "closed" => %w[payed],
+    "payed" => []
+  }.freeze
+
+  included do
+    include AASM
+
+    aasm column: :status, enum: true do
+      state :open, initial: true
+      state :closed, :payed
+
+      event :close do
+        transitions from: :open, to: :closed
+      end
+
+      event :mark_paid do
+        transitions from: %i[open closed], to: :payed
+      end
+    end
+
+    validate :status_transition_must_be_allowed, if: :validate_status_transition?
+  end
+
+  private
+
+  def validate_status_transition?
+    will_save_change_to_status? && !new_record?
+  end
+
+  def status_transition_must_be_allowed
+    from = status_was.to_s
+    to = status.to_s
+    return if from == to
+
+    allowed = PERMITTED_TRANSITIONS.fetch(from, [])
+    return if allowed.include?(to)
+
+    errors.add(:status, "cannot transition from #{from} to #{to}")
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,6 +3,7 @@
 class Order < ApplicationRecord
   include OrganizationScoped
   include OrganizationReindexable
+  include OrderStateMachine
 
   extend Pagy::Search
 

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -3,8 +3,9 @@
 class OrderItem < ApplicationRecord
   class InsufficientStock < StandardError; end
 
+  include OrderItemStateMachine
+
   around_create :reserve_stock_unless_dish
-  before_validation :set_default_status_for_dish, on: :create, if: :dish?
   after_create :recalculate_total
   after_create_commit :broadcast_kitchen_create, if: :dish?
 
@@ -98,10 +99,6 @@ class OrderItem < ApplicationRecord
 
   def recalculate_total
     order.recalculate_total
-  end
-
-  def set_default_status_for_dish
-    self.status ||= :awaiting
   end
 
   def reserve_stock_unless_dish

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -50,52 +50,16 @@ class OrderItem < ApplicationRecord
   end
 
   def broadcast_kitchen_create
-    unless kitchen_broadcastable?
-      log_kitchen_broadcast_skipped('create')
-      return
-    end
-
-    message('create')
-  end
-
-  def message(action)
-    record = OrderItem.includes(:item, order: :table).find(id)
-    payload = ApplicationController.render(
-      template: 'api/v1/kitchens/_kitchen',
-      locals: { kitchen: record }
-    )
-    msg = {
-      obj: JSON.parse(payload),
-      action:
-    }
-    Rails.logger.info(
-      "[KitchenCable] broadcast #{action} order_item=#{record.id} org=#{record.order.organization_id}"
-    )
-    KitchenCableBroadcaster.deliver(organization_id: record.order.organization_id, message: msg)
+    Kitchen::BroadcastOrderItem.call(order_item: self, action: "create")
   end
 
   def broadcast_kitchen_status
-    unless kitchen_broadcastable?
-      log_kitchen_broadcast_skipped('update')
-      return
-    end
+    return unless saved_change_to_status?
 
-    message('update') if saved_change_to_status?
+    Kitchen::BroadcastOrderItem.call(order_item: self, action: "update")
   end
 
   private
-
-  def kitchen_broadcastable?
-    order.open? && order.organization.reload.open?
-  end
-
-  def log_kitchen_broadcast_skipped(action)
-    org = order.organization
-    Rails.logger.info(
-      "[KitchenCable] skipped broadcast #{action} order_item=#{id} " \
-      "order_open=#{order.open?} org_open=#{org.open?} org_id=#{org.id}"
-    )
-  end
 
   def recalculate_total
     order.recalculate_total

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -66,9 +66,6 @@ class Organization < ApplicationRecord
   end
 
   def close_open_orders_when_kitchen_closes
-    closed_count = orders.open.update_all(status: Order.statuses[:closed], updated_at: Time.current)
-    Rails.logger.info(
-      "[Kitchen] organization=#{id} operational_status=closed auto_closed_orders=#{closed_count}"
-    )
+    Organizations::CloseKitchen.call(organization: self)
   end
 end

--- a/app/services/kitchen/broadcast_order_item.rb
+++ b/app/services/kitchen/broadcast_order_item.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Kitchen
+  class BroadcastOrderItem
+    def self.call(order_item:, action:)
+      new(order_item:, action:).call
+    end
+
+    def initialize(order_item:, action:)
+      @order_item = order_item
+      @action = action
+    end
+
+    def call
+      unless broadcastable?
+        log_skipped
+        return false
+      end
+
+      record = OrderItem.includes(:item, order: :table).find(@order_item.id)
+      payload = ApplicationController.render(
+        template: "api/v1/kitchens/_kitchen",
+        locals: { kitchen: record }
+      )
+      message = {
+        obj: JSON.parse(payload),
+        action: @action
+      }
+
+      Rails.logger.info(
+        "[KitchenCable] broadcast #{@action} order_item=#{record.id} org=#{record.order.organization_id}"
+      )
+      KitchenCableBroadcaster.deliver(organization_id: record.order.organization_id, message:)
+
+      true
+    end
+
+    private
+
+    def broadcastable?
+      @order_item.dish? && @order_item.order.open? && @order_item.order.organization.reload.open?
+    end
+
+    def log_skipped
+      org = @order_item.order.organization
+      Rails.logger.info(
+        "[KitchenCable] skipped broadcast #{@action} order_item=#{@order_item.id} " \
+        "order_open=#{@order_item.order.open?} org_open=#{org.open?} org_id=#{org.id}"
+      )
+    end
+  end
+end

--- a/app/services/kitchen/update_item_status.rb
+++ b/app/services/kitchen/update_item_status.rb
@@ -16,6 +16,7 @@ module Kitchen
 
     def call
       raise KitchenClosed if @organization.closed?
+      return @order_item if @status.blank?
 
       @order_item.update(status: @status)
       @order_item

--- a/app/services/kitchen/update_item_status.rb
+++ b/app/services/kitchen/update_item_status.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Kitchen
+  class UpdateItemStatus
+    class KitchenClosed < StandardError; end
+
+    def self.call(order_item:, status:, organization:)
+      new(order_item:, status:, organization:).call
+    end
+
+    def initialize(order_item:, status:, organization:)
+      @order_item = order_item
+      @status = status
+      @organization = organization
+    end
+
+    def call
+      raise KitchenClosed if @organization.closed?
+
+      @order_item.update(status: @status)
+      @order_item
+    end
+  end
+end

--- a/app/services/orders/add_item.rb
+++ b/app/services/orders/add_item.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Orders
+  class AddItem
+    def self.call(order:, params:)
+      new(order:, params:).call
+    end
+
+    def initialize(order:, params:)
+      @order = order
+      @params = params
+    end
+
+    def call
+      item = @order.order_items.build(@params)
+      item.save
+      item
+    end
+  end
+end

--- a/app/services/orders/remove_item.rb
+++ b/app/services/orders/remove_item.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Orders
+  class RemoveItem
+    def self.call(order_item:)
+      order_item.destroy
+      order_item.destroyed?
+    end
+  end
+end

--- a/app/services/orders/update_item.rb
+++ b/app/services/orders/update_item.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Orders
+  class UpdateItem
+    def self.call(order_item:, params:)
+      new(order_item:, params:).call
+    end
+
+    def initialize(order_item:, params:)
+      @order_item = order_item
+      @params = params
+    end
+
+    def call
+      previous_quantity = @order_item.quantity
+
+      OrderItem.transaction do
+        unless @order_item.update(@params)
+          raise ActiveRecord::Rollback
+        end
+
+        @order_item.apply_quantity_change!(previous_quantity:)
+      end
+
+      @order_item
+    rescue OrderItem::InsufficientStock
+      @order_item.errors.add(:quantity, "insufficient stock")
+      @order_item
+    end
+  end
+end

--- a/app/services/organizations/close_kitchen.rb
+++ b/app/services/organizations/close_kitchen.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Organizations
+  class CloseKitchen
+    def self.call(organization:)
+      new(organization:).call
+    end
+
+    def initialize(organization:)
+      @organization = organization
+    end
+
+    def call
+      return 0 unless @organization.closed?
+
+      closed_count = @organization.orders.open.update_all(
+        status: Order.statuses[:closed],
+        updated_at: Time.current
+      )
+
+      Rails.logger.info(
+        "[Kitchen] organization=#{@organization.id} operational_status=closed auto_closed_orders=#{closed_count}"
+      )
+
+      closed_count
+    end
+  end
+end

--- a/docs/order-state-diagram.md
+++ b/docs/order-state-diagram.md
@@ -91,6 +91,8 @@ Statuses `cooking`, `ready`, `empty_stock` are **not used** on non-dish lines (i
 | Service | Responsibility |
 |---------|----------------|
 | `Orders::AddItem` | Build + save item, stock + total side effects |
+| `Orders::UpdateItem` | Update quantity/status with stock adjustment |
+| `Orders::RemoveItem` | Destroy item and release stock |
+| `Kitchen::UpdateItemStatus` | Kitchen status transition with org guard |
+| `Kitchen::BroadcastOrderItem` | Single entry point for AnyCable kitchen payloads |
 | `Organizations::CloseKitchen` | Bulk-close open orders when org kitchen closes |
-| `Kitchen::UpdateItemStatus` | *(planned)* kitchen status transitions with org guard |
-| `Orders::RemoveItem` | *(planned)* destroy + stock release |

--- a/docs/order-state-diagram.md
+++ b/docs/order-state-diagram.md
@@ -1,0 +1,96 @@
+# Order lifecycle — state diagrams
+
+Companion to [plan 06](./plans/06-order-lifecycle.md). Describes **current intended behaviour** after domain hardening.
+
+---
+
+## Order (`Order#status`)
+
+```mermaid
+stateDiagram-v2
+  [*] --> open: create
+  open --> closed: close (manual or kitchen shutdown)
+  open --> payed: mark_paid
+  closed --> payed: mark_paid
+  payed --> [*]
+```
+
+| From | To | Who / trigger |
+|------|-----|----------------|
+| `open` | `closed` | Waiter/admin/cash register via `PATCH /orders/:id`; **auto** when org `operational_status` → `closed` |
+| `open` | `payed` | Staff with order update permission (checkout) |
+| `closed` | `payed` | Staff (pay after tab closed) |
+| `payed` | — | Terminal — no reopen |
+
+**Guards**
+
+- Order items can only be **created/updated/destroyed** while order is `open` (CanCan + model validation).
+- Org kitchen **closed** → kitchen API returns empty queue / 403 on status updates; open orders are bulk-closed.
+
+---
+
+## Order item — dish (kitchen queue)
+
+Default status on create: `awaiting`.
+
+```mermaid
+stateDiagram-v2
+  [*] --> awaiting: add dish to open order
+  awaiting --> cooking: kitchen
+  cooking --> ready: kitchen
+  ready --> with_the_client: waiter / kitchen
+  awaiting --> canceled: staff
+  cooking --> canceled: staff
+  ready --> canceled: staff
+  with_the_client --> [*]
+  canceled --> [*]
+```
+
+Kitchen broadcast (AnyCable) fires on **create** and on **status change** when order and org are both `open`.
+
+---
+
+## Order item — non-dish (stock-backed products)
+
+Default status on create: `awaiting` (enum default). No kitchen queue.
+
+```mermaid
+stateDiagram-v2
+  [*] --> awaiting: add product (stock reserved)
+  awaiting --> with_the_client: served
+  awaiting --> canceled: remove / cancel line
+  with_the_client --> [*]
+  canceled --> [*]
+```
+
+**Stock path:** create reserves stock; destroy releases; quantity change adjusts stock (`OrderItem#apply_quantity_change!`). Dishes skip stock hooks.
+
+Statuses `cooking`, `ready`, `empty_stock` are **not used** on non-dish lines (invalid transition if attempted).
+
+---
+
+## Role × action matrix
+
+| Action | Waiter | Kitchen | Cash register | Admin | Customer |
+|--------|--------|---------|---------------|-------|----------|
+| Create order | ✓ | — | ✓ | ✓ | ✓ (own org) |
+| Read orders (org) | ✓ | — | ✓ | ✓ | — |
+| Update open order (discount, table, status) | ✓ | — | ✓ | ✓ | — |
+| Add / update / remove items (open order) | ✓ | — | ✓ | ✓ | — |
+| Read kitchen queue | ✓ | ✓ | ✓ | ✓ | — |
+| Update dish item status | ✓* | ✓ | ✓* | ✓* | — |
+| Close org kitchen (`operational_status`) | — | — | ✓ | ✓ | — |
+| Auto-close open orders | — | — | — | — | — (system on kitchen close) |
+
+\*Waiter/admin/cash register can update item status via order items API; kitchen role uses `/api/v1/kitchens/:id`.
+
+---
+
+## Services (domain entry points)
+
+| Service | Responsibility |
+|---------|----------------|
+| `Orders::AddItem` | Build + save item, stock + total side effects |
+| `Organizations::CloseKitchen` | Bulk-close open orders when org kitchen closes |
+| `Kitchen::UpdateItemStatus` | *(planned)* kitchen status transitions with org guard |
+| `Orders::RemoveItem` | *(planned)* destroy + stock release |

--- a/docs/plans/06-order-lifecycle.md
+++ b/docs/plans/06-order-lifecycle.md
@@ -40,7 +40,7 @@ Centralize **order and order-item state rules** in explicit domain logic (state 
 
 - [x] `Order` state machine with guards (e.g. cannot add items when closed)
 - [x] `OrderItem` state machine; dish default `awaiting` on create
-- [~] Replace ad-hoc `saved_change_to_status?` checks where possible — kitchen broadcast still uses callback
+- [~] Replace ad-hoc `saved_change_to_status?` checks where possible — broadcast delegated to `Kitchen::BroadcastOrderItem`
 
 **Acceptance:** invalid transitions raise / return 422 with clear error.
 
@@ -49,8 +49,9 @@ Centralize **order and order-item state rules** in explicit domain logic (state 
 ## Phase 3 — Service objects
 
 - [x] `Orders::AddItem.call(order:, params:)` — transaction, stock, broadcast
-- [ ] `Orders::RemoveItem.call(...)`
-- [ ] `Kitchen::UpdateItemStatus.call(...)`
+- [x] `Orders::RemoveItem.call(...)`
+- [x] `Orders::UpdateItem.call(...)` — quantity/status + stock
+- [x] `Kitchen::UpdateItemStatus.call(...)`
 - [x] `Organizations::CloseKitchen` — extracted from org callback; closes open orders
 
 **Acceptance:** controllers thin; specs on services.
@@ -59,8 +60,8 @@ Centralize **order and order-item state rules** in explicit domain logic (state 
 
 ## Phase 4 — Events & side effects
 
-- [ ] Single place for kitchen broadcast after successful commit
-- [ ] `Order#recalculate_total` invoked consistently
+- [x] Single place for kitchen broadcast — `Kitchen::BroadcastOrderItem` (called from model callbacks)
+- [x] `Order#recalculate_total` invoked consistently — via OrderItem callbacks
 - [ ] Idempotency consideration for duplicate add-item requests (optional header)
 
 ---
@@ -68,8 +69,8 @@ Centralize **order and order-item state rules** in explicit domain logic (state 
 ## Phase 5 — Tests
 
 - [x] Model/service specs for every transition (initial set)
-- [ ] Request specs: closed order rejects new items; org closed rejects kitchen update
-- [ ] Regression: dish appears on order show without manual refresh (API response completeness)
+- [x] Request specs: closed order rejects new items; org closed rejects kitchen update
+- [x] Regression: new item appears on order items index after create
 
 ---
 
@@ -77,7 +78,7 @@ Centralize **order and order-item state rules** in explicit domain logic (state 
 
 - [x] Documented state diagrams
 - [x] AASM (or equivalent) on Order / OrderItem
-- [~] Core mutations via service objects
+- [x] Core mutations via service objects
 - [x] Test coverage for invalid transitions (initial set)
 
 ---

--- a/docs/plans/06-order-lifecycle.md
+++ b/docs/plans/06-order-lifecycle.md
@@ -1,7 +1,8 @@
 # Plan: Order lifecycle (domain)
 
-**Status:** not started  
+**Status:** in progress  
 **Project:** ubuteco_api (primary)  
+**Branch:** `feature/order-lifecycle`  
 **Companion:** [ubuteco-react — testing](../../../ubuteco-react/docs/plans/05-testing.md) *(orders/kitchen regression)*  
 **Priority:** P1  
 **Depends on:** [01-multi-tenant](./01-multi-tenant.md) (recommended)  
@@ -27,9 +28,9 @@ Centralize **order and order-item state rules** in explicit domain logic (state 
 
 ## Phase 1 — Document transitions
 
-- [ ] State diagram for `Order` (open → closed, who can close)
-- [ ] State diagram for `OrderItem` (dish vs non-dish, stock paths)
-- [ ] Table: role × allowed action (waiter add item, kitchen update status, admin close org kitchen → auto-close orders)
+- [x] State diagram for `Order` (open → closed, who can close)
+- [x] State diagram for `OrderItem` (dish vs non-dish, stock paths)
+- [x] Table: role × allowed action (waiter add item, kitchen update status, admin close org kitchen → auto-close orders)
 
 **Acceptance:** diagram in this file or `docs/order-state-diagram.md`.
 
@@ -37,9 +38,9 @@ Centralize **order and order-item state rules** in explicit domain logic (state 
 
 ## Phase 2 — State machines (AASM or similar)
 
-- [ ] `Order` state machine with guards (e.g. cannot add items when closed)
-- [ ] `OrderItem` state machine; dish default `awaiting` on create
-- [ ] Replace ad-hoc `saved_change_to_status?` checks where possible
+- [x] `Order` state machine with guards (e.g. cannot add items when closed)
+- [x] `OrderItem` state machine; dish default `awaiting` on create
+- [~] Replace ad-hoc `saved_change_to_status?` checks where possible — kitchen broadcast still uses callback
 
 **Acceptance:** invalid transitions raise / return 422 with clear error.
 
@@ -47,10 +48,10 @@ Centralize **order and order-item state rules** in explicit domain logic (state 
 
 ## Phase 3 — Service objects
 
-- [ ] `Orders::AddItem.call(order:, params:)` — transaction, stock, broadcast
+- [x] `Orders::AddItem.call(order:, params:)` — transaction, stock, broadcast
 - [ ] `Orders::RemoveItem.call(...)`
 - [ ] `Kitchen::UpdateItemStatus.call(...)`
-- [ ] `Organizations::CloseKitchen` already closes orders — link to order close service
+- [x] `Organizations::CloseKitchen` — extracted from org callback; closes open orders
 
 **Acceptance:** controllers thin; specs on services.
 
@@ -66,7 +67,7 @@ Centralize **order and order-item state rules** in explicit domain logic (state 
 
 ## Phase 5 — Tests
 
-- [ ] Model/service specs for every transition
+- [x] Model/service specs for every transition (initial set)
 - [ ] Request specs: closed order rejects new items; org closed rejects kitchen update
 - [ ] Regression: dish appears on order show without manual refresh (API response completeness)
 
@@ -74,14 +75,14 @@ Centralize **order and order-item state rules** in explicit domain logic (state 
 
 ## Definition of done
 
-- [ ] Documented state diagrams
-- [ ] AASM (or equivalent) on Order / OrderItem
-- [ ] Core mutations via service objects
-- [ ] Test coverage for invalid transitions
+- [x] Documented state diagrams
+- [x] AASM (or equivalent) on Order / OrderItem
+- [~] Core mutations via service objects
+- [x] Test coverage for invalid transitions (initial set)
 
 ---
 
 ## References
 
-- `app/models/order.rb`, `order_item.rb`
+- `docs/order-state-diagram.md`
 - `app/controllers/api/v1/orders_controller.rb`, `orders/items_controller.rb`

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -32,7 +32,7 @@ When a plan gets an issue, add `**GitHub:** owner/repo#NN` to the plan header (s
 | 1 | [Multi-tenant](./01-multi-tenant.md) | completed | P0 | — |
 | 2 | [Locale & currency](./02-locale-and-currency.md) | completed | P1 | #1 |
 | 10 | [Users admin API](./10-users-admin-api.md) | not started | P1 | #1 |
-| 6 | [Order lifecycle](./06-order-lifecycle.md) | not started | P1 | #1 |
+| 6 | [Order lifecycle](./06-order-lifecycle.md) | in progress | P1 | #1 |
 | 4 | [Organization dashboard](./04-organization-dashboard.md) | completed | P1 | #1, #2 |
 | 7 | [Search / OpenSearch ops](./07-search-operations.md) | in progress | P2 | #1 |
 | 8 | [API contract & CI/CD](./08-api-contract-and-ci.md) | not started | P2 | — |

--- a/spec/controllers/api/v1/kitchens_controller_spec.rb
+++ b/spec/controllers/api/v1/kitchens_controller_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe Api::V1::KitchensController, type: :request do
     let!(:item) { @orders.sample.order_items.sample }
 
     it 'updates order' do
-      put api_v1_kitchen_path(id: item.id), params: item.to_json, headers: auth_header(@kitchen)
+      put api_v1_kitchen_path(id: item.id),
+          params: { status: 'cooking' }.to_json,
+          headers: auth_header(@kitchen)
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/models/order_item_state_machine_spec.rb
+++ b/spec/models/order_item_state_machine_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe OrderItem, type: :model do
+  let(:organization) { create(:organization) }
+  let(:order) { create(:order, :open, organization: organization) }
+
+  describe "dish status transitions" do
+    let(:dish) { create(:dish, organization: organization) }
+    let(:item) { create(:order_item, order: order, item: dish, status: :awaiting) }
+
+    it "allows awaiting to cooking" do
+      expect(item.update(status: :cooking)).to be true
+    end
+
+    it "allows cooking to ready" do
+      item.update!(status: :cooking)
+
+      expect(item.update(status: :ready)).to be true
+    end
+
+    it "allows ready to with_the_client" do
+      item.update!(status: :cooking)
+      item.update!(status: :ready)
+
+      expect(item.update(status: :with_the_client)).to be true
+    end
+
+    it "rejects skipping cooking (awaiting to ready)" do
+      expect(item.update(status: :ready)).to be false
+      expect(item.errors[:status]).to include("cannot transition from awaiting to ready")
+    end
+
+    it "allows cancel from awaiting" do
+      expect(item.update(status: :canceled)).to be true
+    end
+  end
+
+  describe "non-dish status transitions" do
+    let(:drink) { create(:drink, organization: organization) }
+    let(:item) { create(:order_item, order: order, item: drink, status: :awaiting) }
+
+    it "allows awaiting to with_the_client" do
+      expect(item.update(status: :with_the_client)).to be true
+    end
+
+    it "rejects kitchen-only statuses" do
+      expect(item.update(status: :cooking)).to be false
+      expect(item.errors[:status]).to include("cannot transition from awaiting to cooking")
+    end
+  end
+
+  describe "open order guard" do
+    it "rejects new items on a closed order" do
+      closed_order = create(:order, :closed, organization: organization)
+      drink = create(:drink, organization: organization)
+
+      item = build(:order_item, order: closed_order, item: drink)
+
+      expect(item).not_to be_valid
+      expect(item.errors[:order]).to include("must be open to add items")
+    end
+  end
+end

--- a/spec/models/order_state_machine_spec.rb
+++ b/spec/models/order_state_machine_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Order, type: :model do
+  describe "status transitions" do
+    it "allows open to closed" do
+      order = create(:order, :open)
+
+      expect(order.update(status: :closed)).to be true
+      expect(order).to be_closed
+    end
+
+    it "allows open to payed" do
+      order = create(:order, :open)
+
+      expect(order.update(status: :payed)).to be true
+      expect(order).to be_payed
+    end
+
+    it "allows closed to payed" do
+      order = create(:order, :closed)
+
+      expect(order.update(status: :payed)).to be true
+      expect(order).to be_payed
+    end
+
+    it "rejects reopening a closed order" do
+      order = create(:order, :closed)
+
+      expect(order.update(status: :open)).to be false
+      expect(order.errors[:status]).to include("cannot transition from closed to open")
+    end
+
+    it "rejects transitions from payed" do
+      order = create(:order, :payed)
+
+      expect(order.update(status: :open)).to be false
+      expect(order.errors[:status]).to include("cannot transition from payed to open")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,15 +2,6 @@
 
 ENV['RAILS_ENV'] ||= 'test'
 
-if ENV['RAILS_ENV'] == 'test'
-  require 'simplecov'
-  SimpleCov.start :rails do
-    enable_coverage :branch
-    add_group 'Abilities', 'app/models/abilities'
-    command_name 'rspec'
-  end
-end
-
 require File.expand_path('../config/environment', __dir__)
 
 abort('The Rails environment is running in production mode!') if Rails.env.production?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,8 @@
 
 ENV['RAILS_ENV'] ||= 'test'
 
+require 'support/simplecov'
+
 require File.expand_path('../config/environment', __dir__)
 
 abort('The Rails environment is running in production mode!') if Rails.env.production?

--- a/spec/requests/api/v1/kitchens_spec.rb
+++ b/spec/requests/api/v1/kitchens_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Api::V1::KitchensController, type: :request do
       response 200, 'Ok' do
         let(:Authorization) { auth_header(@kitchen)['Authorization'] }
         let(:id) { @orders.sample.order_items.sample.id }
-        let(:params) { attributes_for(:order_item) }
+        let(:params) { { status: "cooking" } }
         schema '$ref' => '#/components/schemas/kitchen_item'
         run_test!
       end

--- a/spec/requests/order_lifecycle_spec.rb
+++ b/spec/requests/order_lifecycle_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Order lifecycle guards", type: :request do
+  let(:organization) { create(:organization) }
+  let(:waiter) { create(:user, :waiter, organization: organization) }
+  let(:kitchen_user) { create(:user, :kitchen, organization: organization) }
+  let(:open_order) { create(:order, :open, organization: organization, user: waiter) }
+  let(:closed_order) { create(:order, :closed, organization: organization, user: waiter) }
+  let(:drink) { create(:drink, organization: organization, quantity_stock: 10) }
+  let(:dish) { create(:dish, organization: organization) }
+  let!(:kitchen_item) { create(:order_item, order: open_order, item: dish, status: :awaiting) }
+
+  describe "POST /api/v1/orders/:order_id/items" do
+    it "rejects adding items to a closed order" do
+      post api_v1_order_items_path(closed_order),
+           params: {
+             item_type: drink.model_name,
+             item_id: drink.id,
+             quantity: 1
+           }.to_json,
+           headers: auth_header(waiter)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "includes the new item on the order items index after create" do
+      post api_v1_order_items_path(open_order),
+           params: {
+             item_type: dish.model_name,
+             item_id: dish.id,
+             quantity: 1
+           }.to_json,
+           headers: auth_header(waiter)
+
+      expect(response).to have_http_status(:created)
+      created_id = response.parsed_body.fetch("id")
+
+      get api_v1_order_items_path(open_order), headers: auth_header(waiter)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.pluck("id")).to include(created_id)
+    end
+  end
+
+  describe "PUT /api/v1/kitchens/:id" do
+    it "returns forbidden when organization kitchen is closed" do
+      organization.update!(operational_status: :closed)
+
+      put api_v1_kitchen_path(kitchen_item),
+          params: { status: "cooking" }.to_json,
+          headers: auth_header(kitchen_user)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(kitchen_item.reload).to be_awaiting
+    end
+  end
+end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Rack::Attack throttles", type: :request do
 
   after do
     Rack::Attack.reset!
+    Rack::Attack.enabled = false
   end
 
   describe "POST /auth/sign_in" do

--- a/spec/services/kitchen/broadcast_order_item_spec.rb
+++ b/spec/services/kitchen/broadcast_order_item_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Kitchen::BroadcastOrderItem do
+  include ActionCable::TestHelper
+
+  let(:organization) { create(:organization) }
+  let(:order) { create(:order, :open, organization: organization) }
+  let(:dish) { create(:dish, organization: organization) }
+
+  it "broadcasts when order and kitchen are open" do
+    item = create(:order_item, order: order, item: dish)
+
+    expect do
+      described_class.call(order_item: item, action: "update")
+    end.to have_broadcasted_to("kitchens_#{organization.id}")
+  end
+
+  it "skips broadcast when organization kitchen is closed" do
+    item = create(:order_item, order: order, item: dish)
+    organization.update!(operational_status: :closed)
+
+    expect do
+      described_class.call(order_item: item, action: "update")
+    end.not_to have_broadcasted_to("kitchens_#{organization.id}")
+  end
+end

--- a/spec/services/kitchen/update_item_status_spec.rb
+++ b/spec/services/kitchen/update_item_status_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Kitchen::UpdateItemStatus do
+  let(:organization) { create(:organization) }
+  let(:order) { create(:order, :open, organization: organization) }
+  let(:dish) { create(:dish, organization: organization) }
+  let(:order_item) { create(:order_item, order: order, item: dish, status: :awaiting) }
+
+  it "updates dish status when kitchen is open" do
+    result = described_class.call(order_item: order_item, status: "cooking", organization: organization)
+
+    expect(result).to be_cooking
+  end
+
+  it "raises when kitchen is closed" do
+    organization.update!(operational_status: :closed)
+
+    expect do
+      described_class.call(order_item: order_item, status: "cooking", organization: organization)
+    end.to raise_error(described_class::KitchenClosed)
+  end
+
+  it "rejects invalid transitions" do
+    result = described_class.call(order_item: order_item, status: "ready", organization: organization)
+
+    expect(result.errors[:status]).to be_present
+  end
+end

--- a/spec/services/orders/add_item_spec.rb
+++ b/spec/services/orders/add_item_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orders::AddItem do
+  let(:organization) { create(:organization) }
+  let(:order) { create(:order, :open, organization: organization) }
+
+  it "creates an order item and recalculates the order total" do
+    drink = create(:drink, organization: organization, price: 5, quantity_stock: 10)
+
+    item = described_class.call(
+      order: order,
+      params: { item: drink, item_id: drink.id, item_type: drink.model_name, quantity: 2 }
+    )
+
+    expect(item).to be_persisted
+    expect(order.reload.total_cents).to eq(drink.price_cents * 2)
+    expect(drink.reload.quantity_stock).to eq(8)
+  end
+
+  it "returns an invalid item when params are missing" do
+    item = described_class.call(order: order, params: {})
+
+    expect(item).not_to be_persisted
+    expect(item.errors[:quantity]).to be_present
+  end
+end

--- a/spec/services/orders/remove_item_spec.rb
+++ b/spec/services/orders/remove_item_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orders::RemoveItem do
+  let(:organization) { create(:organization) }
+  let(:order) { create(:order, :open, organization: organization) }
+
+  it "destroys the item and restores stock" do
+    drink = create(:drink, organization: organization, quantity_stock: 10)
+    item = create(:order_item, order: order, item: drink, quantity: 3)
+
+    expect(described_class.call(order_item: item)).to be true
+    expect(OrderItem.exists?(item.id)).to be false
+    expect(drink.reload.quantity_stock).to eq(10)
+  end
+end

--- a/spec/services/orders/update_item_spec.rb
+++ b/spec/services/orders/update_item_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orders::UpdateItem do
+  let(:organization) { create(:organization) }
+  let(:order) { create(:order, :open, organization: organization) }
+
+  it "updates quantity and adjusts stock" do
+    drink = create(:drink, organization: organization, quantity_stock: 10)
+    item = create(:order_item, order: order, item: drink, quantity: 2)
+
+    result = described_class.call(order_item: item, params: { quantity: 4 })
+
+    expect(result.errors).to be_empty
+    expect(drink.reload.quantity_stock).to eq(6)
+  end
+
+  it "returns errors for invalid status transitions" do
+    dish = create(:dish, organization: organization)
+    item = create(:order_item, order: order, item: dish, status: :awaiting)
+
+    result = described_class.call(order_item: item, params: { status: "ready" })
+
+    expect(result.errors[:status]).to be_present
+  end
+end

--- a/spec/services/organizations/close_kitchen_spec.rb
+++ b/spec/services/organizations/close_kitchen_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Organizations::CloseKitchen do
+  it "closes all open orders when the organization kitchen is closed" do
+    organization = create(:organization, operational_status: :closed)
+    open_order = create(:order, :open, organization: organization)
+    closed_order = create(:order, :closed, organization: organization)
+
+    count = described_class.call(organization: organization)
+
+    expect(count).to eq(1)
+    expect(open_order.reload).to be_closed
+    expect(closed_order.reload).to be_closed
+  end
+
+  it "returns zero when the organization kitchen is still open" do
+    organization = create(:organization, operational_status: :open)
+    create(:order, :open, organization: organization)
+
+    expect(described_class.call(organization: organization)).to eq(0)
+  end
+end

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -2,6 +2,7 @@
 
 if ENV['RAILS_ENV'] == 'test'
   require 'simplecov'
+  require 'simplecov-cobertura'
 
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+if ENV['RAILS_ENV'] == 'test'
+  require 'simplecov'
+
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::CoberturaFormatter
+  ]
+
+  SimpleCov.start :rails do
+    enable_coverage :branch
+    add_group 'Abilities', 'app/models/abilities'
+    add_group 'Services', 'app/services'
+    command_name 'rspec'
+  end
+end


### PR DESCRIPTION
## Summary

- **Phase 1–2:** State diagrams in `docs/order-state-diagram.md`; AASM transition validation on `Order` and `OrderItem` (dish vs non-dish flows)
- **Phase 3:** Service objects — `Orders::AddItem`, `Orders::UpdateItem`, `Orders::RemoveItem`, `Kitchen::UpdateItemStatus`, `Organizations::CloseKitchen`
- **Phase 4:** Centralized kitchen broadcast via `Kitchen::BroadcastOrderItem`
- **Phase 5:** Model/service specs + request specs (closed order → 403 on add item; closed kitchen → 403 on status update)

## Test plan

- [ ] `bundle exec rspec spec/models/order_* spec/services/orders spec/services/kitchen spec/requests/order_lifecycle_spec.rb`
- [ ] `bundle exec rspec spec/requests/api/v1/orders/items_spec.rb spec/controllers/api/v1/kitchens_controller_spec.rb`
- [ ] Manual: add dish to open order → appears in kitchen queue; close org kitchen → orders closed, kitchen update blocked


Made with [Cursor](https://cursor.com)