### PR TITLE
docs(ai): agent context, ADRs, drift checks, and multi-tool entry points

### DIFF
--- a/.cursor/rules/openapi-contract.mdc
+++ b/.cursor/rules/openapi-contract.mdc
@@ -1,0 +1,28 @@
+---
+description: OpenAPI contract and rswag patterns when changing API surface
+globs: app/controllers/**/*.rb,spec/requests/**/*.rb,spec/swagger_helper.rb,swagger/**/*.yaml,docs/swagger.yaml
+alwaysApply: false
+---
+
+# OpenAPI contract (ubuteco_api)
+
+Canonical contract: [ADR 005](../../docs/decisions/005-openapi-as-contract-source.md).
+
+## Before changing JSON shape or routes
+
+1. Read `config/routes.rb` and `swagger/v1/swagger.yaml`.
+2. Mirror nearest existing controller + rswag spec in `spec/requests/api/v1/`.
+
+## After API contract changes
+
+1. Update rswag request spec (`errors_response` schema for 422/403).
+2. Run `bundle exec rake openapi:refresh` or `openapi:drift_check`.
+3. Commit `swagger/v1/swagger.yaml` and `docs/swagger.yaml`.
+
+## Errors
+
+Use structured format via `ApiErrorRenderable` — [ADR 004](../../docs/decisions/004-structured-api-errors.md). Do not return bare string arrays.
+
+## Testing
+
+See [testing.md](../../docs/context/testing.md).

--- a/.cursor/rules/plan-and-git-workflow.mdc
+++ b/.cursor/rules/plan-and-git-workflow.mdc
@@ -30,6 +30,7 @@ Plan-only edits with **no code** may go direct to **`master`** per AGENTS.md.
 | Brakeman | `bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error` |
 | bundler-audit | `bin/bundler-audit check --update` |
 | OpenAPI drift (if contract changed) | `bundle exec rake openapi:drift_check` |
+| Plan status drift (if plan docs changed) | `bin/plans_drift_check` |
 
 Shortcut: `bin/ci`. Do not open a PR with failures.
 

--- a/.cursor/rules/tenant-safety.mdc
+++ b/.cursor/rules/tenant-safety.mdc
@@ -1,0 +1,26 @@
+---
+description: Multi-tenant scoping, Current, and CanCan rules for API code
+globs: app/controllers/**/*.rb,app/models/**/*.rb,app/models/abilities/**/*.rb,app/services/**/*.rb
+alwaysApply: false
+---
+
+# Tenant safety (ubuteco_api)
+
+Shared-schema multi-tenant — see [ADR 001](../../docs/decisions/001-shared-schema-multi-tenant.md) and [architecture.md](../../docs/context/architecture.md).
+
+## Rules
+
+- Request context: `Current.user`, `Current.organization` (`SetCurrentTenant` on every request).
+- Org-owned records: scope by `organization_id`; abilities under `app/models/abilities/`.
+- **Never** trust client-supplied `organization_id` on create — merge from `current_user.organization_id` or `Current.organization`.
+- Do **not** add `default_scope` for tenant isolation.
+- Jobs/console: set `Current` explicitly or pass `organization_id` — Sidekiq has no automatic tenant.
+
+## New org-scoped resources
+
+- Add cross-tenant specs in `spec/security/cross_tenant/`.
+- Verify CanCan rules in the matching ability class for each role.
+
+## Pitfalls
+
+See [common-ai-pitfalls.md](../../docs/context/common-ai-pitfalls.md).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,12 @@
+# Copilot instructions — ubuteco_api
+
+Read **[AGENTS.md](./AGENTS.md)** before suggesting or editing code in this repository.
+
+- Workflow (commits, PRs, quality gates): [docs/workflow-plans-and-git.md](docs/workflow-plans-and-git.md)
+- Architecture & domain context: [docs/context/](docs/context/)
+- Active work: pick one plan from [docs/plans/README.md](docs/plans/README.md)
+- Small fixes: [docs/backlog/README.md](docs/backlog/README.md)
+
+Stack: Ruby 4 / Rails 8.1 API-only, PostgreSQL, Sidekiq, Searchkick + OpenSearch, AnyCable, Devise JWT, CanCanCan.
+
+Do not run `db:migrate` or destructive DB commands unless the user explicitly requests it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Check OpenAPI drift
         run: bundle exec rake openapi:drift_check
 
+      - name: Check plan status drift
+        run: bin/plans_drift_check
+
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,10 @@ Instructions for AI assistants working in this repository.
 
 1. Read [docs/plans/README.md](docs/plans/README.md) — pick **one plan**, check status and dependencies.
 2. Read [docs/workflow-plans-and-git.md](docs/workflow-plans-and-git.md) — small commits, update plan before PR (**canonical** for all agents; not only Cursor).
-3. Read [docs/context/architecture.md](docs/context/architecture.md) for tenant model and request flow.
-4. Read [docs/dev-setup.md](docs/dev-setup.md) for ports and local commands.
+3. Read [docs/context/common-ai-pitfalls.md](docs/context/common-ai-pitfalls.md) — frequent agent mistakes in this repo.
+4. Read [docs/context/architecture.md](docs/context/architecture.md) for tenant model and request flow.
+5. Read domain context for your plan area (orders, users, inventory, etc.) — see [Key paths](#key-paths).
+6. Read [docs/dev-setup.md](docs/dev-setup.md) for ports and local commands.
 
 ## Branching
 
@@ -47,9 +49,9 @@ Instructions for AI assistants working in this repository.
 
 - Tenant logic: `Current.user` / `Current.organization` — see `app/models/current.rb`.
 - Org-owned records: scope by `organization_id`; never trust `organization_id` from client params on create.
-- Errors: JSON array of strings, often `422` with `errors.full_messages`.
-- Specs: RSpec; request specs for API; mirror patterns in `spec/controllers/api/v1/`.
-- After controller/schema changes: update Swagger (`spec/swagger_helper.rb`) when the plan calls for it.
+- Errors: structured JSON via `ApiErrorRenderable` — `{ errors: [{ code, field?, message }] }`. Use `render_model_errors` / `render_api_errors`. See [docs/context/api-conventions.md](docs/context/api-conventions.md) and [ADR 004](docs/decisions/004-structured-api-errors.md).
+- Specs: RSpec; request specs for API; cross-tenant cases required for org-scoped resources. See [docs/context/testing.md](docs/context/testing.md).
+- After controller/schema changes: update rswag + run `openapi:drift_check` when the contract changes — [ADR 005](docs/decisions/005-openapi-as-contract-source.md).
 
 ## Key paths
 
@@ -57,8 +59,14 @@ Instructions for AI assistants working in this repository.
 |------|------|
 | Plans | `docs/plans/` |
 | Workflow (plans, commits, PRs) | `docs/workflow-plans-and-git.md` |
-| Context | `docs/context/` |
+| AI pitfalls | `docs/context/common-ai-pitfalls.md` |
+| Context (stable) | `docs/context/` |
+| Orders & kitchen | `docs/context/orders-lifecycle.md` |
+| Users & platform | `docs/context/users-and-platform.md` |
+| Inventory & stock | `docs/context/inventory-stock.md` |
+| Testing patterns | `docs/context/testing.md` |
 | ADRs | `docs/decisions/` |
+| OpenAPI (canonical) | `swagger/v1/swagger.yaml` |
 | Tenant | `app/models/current.rb`, `app/controllers/concerns/set_current_tenant.rb` |
 | Abilities | `app/models/abilities/` |
 | Platform (super admin) | `app/controllers/api/v1/platform/` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Instructions for AI assistants working in this repository.
 
+**Also:** [CLAUDE.md](CLAUDE.md) (Claude Code) · [.github/copilot-instructions.md](.github/copilot-instructions.md) (GitHub Copilot) — both point here.
+
 ## Stack
 
 - Ruby 4 / Rails 8.1 API-only
@@ -19,14 +21,16 @@ Instructions for AI assistants working in this repository.
 1. Read [docs/plans/README.md](docs/plans/README.md) — pick **one plan**, check status and dependencies.
 2. Read [docs/workflow-plans-and-git.md](docs/workflow-plans-and-git.md) — small commits, update plan before PR (**canonical** for all agents; not only Cursor).
 3. Read [docs/context/common-ai-pitfalls.md](docs/context/common-ai-pitfalls.md) — frequent agent mistakes in this repo.
-4. Read [docs/context/architecture.md](docs/context/architecture.md) for tenant model and request flow.
-5. Read domain context for your plan area (orders, users, inventory, etc.) — see [Key paths](#key-paths).
-6. Read [docs/dev-setup.md](docs/dev-setup.md) for ports and local commands.
+4. Small API bugs / polish: [docs/backlog/README.md](docs/backlog/README.md) — promote to a plan if scope grows.
+5. Read [docs/context/architecture.md](docs/context/architecture.md) for tenant model and request flow.
+6. Read domain context for your plan area — see [Key paths](#key-paths).
+7. Read [docs/dev-setup.md](docs/dev-setup.md) for ports and local commands.
 
 ## Branching
 
 - **Implementation** (code): one plan = one branch — `feature/<plan-slug>` (e.g. `feature/locale-and-currency`). Do not mix unrelated plans on the same branch.
 - **Plan docs** (`docs/plans/`, status checkboxes, new plan files): commit **directly on `master`** — no feature branch or PR required.
+- **Backlog docs** (`docs/backlog/`): commit **directly on `master`** when text-only.
 - **Other docs-only** (context, ADRs, dev-setup): also fine on `master`, or `docs/<topic>` if you prefer a short-lived branch.
 
 ## Plans, commits & PRs
@@ -58,12 +62,16 @@ Instructions for AI assistants working in this repository.
 | Area | Path |
 |------|------|
 | Plans | `docs/plans/` |
+| Backlog | `docs/backlog/` |
 | Workflow (plans, commits, PRs) | `docs/workflow-plans-and-git.md` |
 | AI pitfalls | `docs/context/common-ai-pitfalls.md` |
 | Context (stable) | `docs/context/` |
 | Orders & kitchen | `docs/context/orders-lifecycle.md` |
 | Users & platform | `docs/context/users-and-platform.md` |
 | Inventory & stock | `docs/context/inventory-stock.md` |
+| Search & OpenSearch | `docs/context/search-and-opensearch.md` |
+| Dashboard | `docs/context/dashboard.md` |
+| i18n & money | `docs/context/i18n-and-money.md` |
 | Testing patterns | `docs/context/testing.md` |
 | ADRs | `docs/decisions/` |
 | OpenAPI (canonical) | `swagger/v1/swagger.yaml` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md — ubuteco_api
+
+Instructions for Claude Code and other agents: **read [AGENTS.md](./AGENTS.md) first.**
+
+Canonical workflow: [docs/workflow-plans-and-git.md](docs/workflow-plans-and-git.md) (not Cursor-only).
+
+Quick links:
+
+- [docs/context/common-ai-pitfalls.md](docs/context/common-ai-pitfalls.md)
+- [docs/context/testing.md](docs/context/testing.md)
+- [docs/plans/README.md](docs/plans/README.md)
+- [docs/backlog/README.md](docs/backlog/README.md)
+
+Do not run destructive DB commands or commit secrets unless explicitly asked.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ High-level view of how the main pieces connect in **local development** (Docker 
 
 **Roadmap / improvement plans:** [docs/plans/README.md](docs/plans/README.md) — multi-tenant through CI/CD, order lifecycle, inventory, users API, and more.
 
-**AI assistants:** [AGENTS.md](AGENTS.md) · [docs/context/](docs/context/) · [docs/dev-setup.md](docs/dev-setup.md)
+**AI assistants:** [AGENTS.md](AGENTS.md) · [docs/context/](docs/context/) (incl. [pitfalls](docs/context/common-ai-pitfalls.md), [testing](docs/context/testing.md)) · [docs/dev-setup.md](docs/dev-setup.md)
 
 #### Components
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ High-level view of how the main pieces connect in **local development** (Docker 
 
 **Roadmap / improvement plans:** [docs/plans/README.md](docs/plans/README.md) — multi-tenant through CI/CD, order lifecycle, inventory, users API, and more.
 
-**AI assistants:** [AGENTS.md](AGENTS.md) · [docs/context/](docs/context/) (incl. [pitfalls](docs/context/common-ai-pitfalls.md), [testing](docs/context/testing.md)) · [docs/dev-setup.md](docs/dev-setup.md)
+**AI assistants:** [AGENTS.md](AGENTS.md) · [CLAUDE.md](CLAUDE.md) · [docs/context/](docs/context/) · [docs/backlog/](docs/backlog/) · [docs/dev-setup.md](docs/dev-setup.md)
 
 #### Components
 

--- a/bin/plans_drift_check
+++ b/bin/plans_drift_check
@@ -1,0 +1,82 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Verifies docs/plans/README.md status column matches each plan's **Status:** header.
+# Usage: bin/plans_drift_check
+
+ROOT = File.expand_path("..", __dir__)
+PLANS_DIR = File.join(ROOT, "docs/plans")
+README = File.join(PLANS_DIR, "README.md")
+
+KNOWN_STATUSES = [
+  "not started",
+  "in progress",
+  "completed"
+].freeze
+
+def normalize_status(raw)
+  text = raw.to_s.strip.downcase.gsub(/\s*\(.*\)\z/, "").strip
+  KNOWN_STATUSES.find { |s| text.start_with?(s) } || text
+end
+
+def parse_readme_table
+  entries = []
+  File.readlines(README, chomp: true).each do |line|
+    next unless line.match?(/^\|\s*\d+\s*\|/)
+
+    parts = line.split("|").map(&:strip).reject(&:empty?)
+    next if parts.size < 3
+
+    link = parts[1]
+    link_match = link&.match(/\A\[.+?\]\(\.\/(.+?)\)\z/)
+    next unless link_match
+
+    file = link_match[1]
+    readme_status = normalize_status(parts[2])
+    entries << { file: file, readme_status: readme_status }
+  end
+  entries
+end
+
+def plan_header_status(path)
+  content = File.read(path)
+  match = content.match(/\*\*Status:\*\*\s*(.+)/)
+  return nil unless match
+
+  normalize_status(match[1])
+end
+
+entries = parse_readme_table
+errors = []
+
+if entries.empty?
+  warn "plans_drift_check: no plan rows found in #{README}"
+  exit 1
+end
+
+entries.each do |entry|
+  path = File.join(PLANS_DIR, entry[:file])
+  unless File.file?(path)
+    errors << "#{entry[:file]}: listed in README but file missing"
+    next
+  end
+
+  header_status = plan_header_status(path)
+  if header_status.nil?
+    errors << "#{entry[:file]}: missing **Status:** header"
+    next
+  end
+
+  next if header_status == entry[:readme_status]
+
+  errors << "#{entry[:file]}: README=#{entry[:readme_status].inspect} header=#{header_status.inspect}"
+end
+
+if errors.any?
+  warn "Plan status drift detected (#{errors.size}):"
+  errors.each { |e| warn "  - #{e}" }
+  warn "Update docs/plans/README.md or the plan **Status:** header so they match."
+  exit 1
+end
+
+puts "Plan status OK (#{entries.size} plans checked)."

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -11,6 +11,7 @@ CI.run do
   step 'Security: Brakeman code analysis', 'bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error'
   step 'Tests: RSpec', 'bundle exec rspec'
   step 'OpenAPI: drift check', 'bundle exec rake openapi:drift_check'
+  step 'Docs: plan status drift check', 'bin/plans_drift_check'
   step 'Tests: Seeds', 'env RAILS_ENV=test bin/rails db:seed:replant'
 
   # Optional: Run system tests

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -1,0 +1,55 @@
+# Backlog — bugs & quick improvements (API)
+
+Lightweight triage for **small, scoped** API fixes — without the full multi-phase structure of [plans](../plans/README.md).
+
+## When to use what
+
+| Situation | Where |
+|-----------|--------|
+| Multi-phase feature, new domain, API + React pairing | [docs/plans/](../plans/README.md) |
+| Single bug, small API fix, one-endpoint polish | **This backlog** |
+| Architectural decision with long-term impact | [docs/decisions/](../decisions/) |
+| Frequent agent mistakes | [context/common-ai-pitfalls.md](../context/common-ai-pitfalls.md) |
+
+If a backlog item grows beyond ~0.5 sprint or needs phased rollout, **promote it to a plan** (copy [TEMPLATE](../plans/TEMPLATE.md), add to plans README, open `feature/<slug>` branch).
+
+## Entry format
+
+One file per item: `NNN-short-slug.md` (zero-padded number, kebab slug).
+
+```markdown
+# <Title>
+
+**Status:** open | in progress | done | wontfix  
+**Priority:** P0 | P1 | P2 | P3  
+**Area:** e.g. orders, search, auth  
+**Plan:** link if promoted, or —  
+**Branch:** `fix/<slug>` or `feature/<plan-slug>`
+
+## Problem
+
+What breaks / wrong behaviour.
+
+## Expected
+
+Correct behaviour.
+
+## Notes
+
+Controllers, specs, related issues.
+```
+
+## Status legend
+
+`open` · `in progress` · `done` · `wontfix`
+
+## Index
+
+| # | Item | Priority | Status |
+|---|------|----------|--------|
+| — | *(empty — add entries as needed)* | — | — |
+
+## Workflow
+
+- Backlog-only edits → commit on **`master`** (no PR), same as plan doc text updates per [AGENTS.md](../../AGENTS.md).
+- Code fix → `fix/<slug>` branch, small commits, quality gates before PR.

--- a/docs/context/api-conventions.md
+++ b/docs/context/api-conventions.md
@@ -4,9 +4,42 @@
 
 - JSON API under `/api/v1/`
 - Success: resource JSON or `{ data, meta }` for paginated index (check existing jbuilder for each controller)
-- Validation errors: `422` with JSON array of human-readable strings (often `errors.full_messages`)
+- **Validation / domain errors:** `422` (or other status) with structured JSON — see [Error responses](#error-responses)
 - Delete success: `204 No Content`
-- Auth failure: `401`; forbidden: `403`
+- Auth failure: `401`; forbidden: `403` (may include structured error body for known cases)
+
+## Error responses
+
+Standard shape (all v1 controllers via `ApiErrorRenderable`):
+
+```json
+{
+  "errors": [
+    {
+      "code": "validation_error",
+      "field": "email",
+      "message": "Email has already been taken"
+    }
+  ]
+}
+```
+
+| Code | HTTP | When |
+|------|------|------|
+| `validation_error` | 422 | ActiveRecord / model validation |
+| `insufficient_stock` | 422 | Order item stock guard |
+| `kitchen_closed` | 403 | Kitchen action when org is closed |
+| `account_deletion_forbidden` | 403 | Non-admin self-delete |
+| `role_assignment_forbidden` | 403 | Assigning `SUPER_ADMIN` |
+| `rate_limit_exceeded` | 429 | Rack::Attack |
+| `search_unavailable` | 503 | OpenSearch down |
+| `error` | varies | Generic fallback |
+
+Controllers: `render_model_errors(record)`, `render_api_errors([{ code:, field:, message: }])`, `render_i18n_api_error(code, ...)`.
+
+Messages use organization locale via `SetOrganizationRegional`. Attribute labels: `config/locales/models/{model}/{locale}.yml`.
+
+See [ADR 004](../decisions/004-structured-api-errors.md). Auth, CORS, rate limits: [plans/api-conventions.md](../plans/api-conventions.md).
 
 ## Authentication
 
@@ -54,6 +87,7 @@ Active Storage for attachments (e.g. org logo, avatars). URLs may appear as `log
 - Specs: `spec/requests/api/v1/*_spec.rb` with rswag
 - Schema definitions: `spec/swagger_helper.rb`
 - Regenerate after API contract changes: `bundle exec rake openapi:refresh`
+- See [ADR 005](../decisions/005-openapi-as-contract-source.md) and [testing.md](./testing.md)
 
 ## Idempotency / migrations
 

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -57,3 +57,17 @@ config/routes.rb
 
 - [001-shared-schema-multi-tenant.md](../decisions/001-shared-schema-multi-tenant.md)
 - [003-react-only-frontend.md](../decisions/003-react-only-frontend.md)
+- [004-structured-api-errors.md](../decisions/004-structured-api-errors.md)
+- [005-openapi-as-contract-source.md](../decisions/005-openapi-as-contract-source.md)
+
+## Domain context (for feature work)
+
+| Domain | Doc |
+|--------|-----|
+| Orders & kitchen | [orders-lifecycle.md](./orders-lifecycle.md) |
+| Users & platform admin | [users-and-platform.md](./users-and-platform.md) |
+| Inventory & stock | [inventory-stock.md](./inventory-stock.md) |
+| API conventions | [api-conventions.md](./api-conventions.md) |
+| Roles summary | [roles-and-access.md](./roles-and-access.md) |
+| Testing | [testing.md](./testing.md) |
+| AI pitfalls | [common-ai-pitfalls.md](./common-ai-pitfalls.md) |

--- a/docs/context/architecture.md
+++ b/docs/context/architecture.md
@@ -15,7 +15,7 @@ Stable reference for how ubuteco_api is structured. For active work items, see [
 | Search | Searchkick + org filters via `SearchkickAuthorizable` |
 | Real-time | AnyCable streams keyed by org (e.g. kitchen) |
 
-Jobs and console **must** set `Current` explicitly or pass `organization_id` — there is no automatic tenant in Sidekiq.
+Jobs and console **must** set `Current` explicitly or pass `organization_id` — there is no automatic tenant in Sidekiq. See [ADR 006](../decisions/006-jobs-and-current-tenant.md).
 
 ## API surface
 
@@ -59,6 +59,7 @@ config/routes.rb
 - [003-react-only-frontend.md](../decisions/003-react-only-frontend.md)
 - [004-structured-api-errors.md](../decisions/004-structured-api-errors.md)
 - [005-openapi-as-contract-source.md](../decisions/005-openapi-as-contract-source.md)
+- [006-jobs-and-current-tenant.md](../decisions/006-jobs-and-current-tenant.md)
 
 ## Domain context (for feature work)
 
@@ -67,6 +68,9 @@ config/routes.rb
 | Orders & kitchen | [orders-lifecycle.md](./orders-lifecycle.md) |
 | Users & platform admin | [users-and-platform.md](./users-and-platform.md) |
 | Inventory & stock | [inventory-stock.md](./inventory-stock.md) |
+| Search & OpenSearch | [search-and-opensearch.md](./search-and-opensearch.md) |
+| Dashboard | [dashboard.md](./dashboard.md) |
+| i18n & money | [i18n-and-money.md](./i18n-and-money.md) |
 | API conventions | [api-conventions.md](./api-conventions.md) |
 | Roles summary | [roles-and-access.md](./roles-and-access.md) |
 | Testing | [testing.md](./testing.md) |

--- a/docs/context/common-ai-pitfalls.md
+++ b/docs/context/common-ai-pitfalls.md
@@ -51,10 +51,26 @@ Lessons from real mistakes when using agents on this codebase. Read before large
 | Commit `.env` or credentials | Never. |
 | Force-push `master` | Never. |
 
+## Search & OpenSearch
+
+| Pitfall | Correct approach |
+|---------|------------------|
+| Unscoped `Model.search` in controllers | `pagy_search_authorized(Model)` — see [search-and-opensearch.md](./search-and-opensearch.md). |
+| Full-class reindex in app code | Use `ReindexJob` or rake with org/model scope; full rebuild needs `ALLOW_FULL_SEARCH_REINDEX=1`. |
+| Assume `Current` in Sidekiq jobs | Set `Current.organization` or pass `organization_id` — [ADR 006](../decisions/006-jobs-and-current-tenant.md). |
+
+## Dashboard & i18n
+
+| Pitfall | Correct approach |
+|---------|------------------|
+| Dashboard dates in server UTC | Use org timezone via `Organizations::Dashboard::RangeParser` — [dashboard.md](./dashboard.md). |
+| Hardcode `BRL` / `pt-BR` | Org-level locale/currency via `SetOrganizationRegional` — [i18n-and-money.md](./i18n-and-money.md). |
+
 ## Process
 
 | Pitfall | Correct approach |
 |---------|------------------|
 | Open PR without updating plan checkboxes | Update `docs/plans/NN-*.md` + README on same branch. |
 | Skip quality gates | Run `bin/ci` or individual checks before push. |
+| Plan README status ≠ plan header | Run `bin/plans_drift_check` after editing plan docs. |
 | Large single commit | Small commits: `feat`, `test`, `docs` per logical change. |

--- a/docs/context/common-ai-pitfalls.md
+++ b/docs/context/common-ai-pitfalls.md
@@ -1,0 +1,60 @@
+# Common AI pitfalls — ubuteco_api
+
+Lessons from real mistakes when using agents on this codebase. Read before large changes.
+
+## Architecture & legacy
+
+| Pitfall | Correct approach |
+|---------|------------------|
+| Port patterns from Angular `ubuteco_spa` | **Abandoned.** Active UI is [ubuteco-react](../../../ubuteco-react). See [ADR 003](../decisions/003-react-only-frontend.md). |
+| Propose schema-per-tenant (Apartment) | **Rejected.** Shared schema + `organization_id`. See [ADR 001](../decisions/001-shared-schema-multi-tenant.md). |
+| Mix unrelated plans on one branch | One plan → `feature/<slug>` → one PR. See [workflow-plans-and-git.md](../workflow-plans-and-git.md). |
+
+## Multi-tenant
+
+| Pitfall | Correct approach |
+|---------|------------------|
+| Trust `organization_id` from client params on create | Set tenant from `Current.organization` / `current_user.organization_id` in controller strong params. |
+| Rely on `default_scope` for isolation | Explicit scoping in abilities and queries. |
+| Skip cross-tenant spec for new resource | Add case under `spec/security/cross_tenant/`. |
+| Forget `Current` in Sidekiq jobs | Pass `organization_id` explicitly or set `Current` in job — no automatic tenant in background work. |
+
+## API contract
+
+| Pitfall | Correct approach |
+|---------|------------------|
+| Change controller JSON without updating OpenAPI | Regenerate rswag + `rake openapi:drift_check`. See [ADR 005](../decisions/005-openapi-as-contract-source.md). |
+| Return bare `errors.full_messages` array | Use `ApiErrorRenderable` — `render_model_errors` / `render_api_errors`. See [ADR 004](../decisions/004-structured-api-errors.md). |
+| Invent endpoint paths | Check `config/routes.rb` and `swagger/v1/swagger.yaml` first. |
+
+## Domain logic
+
+| Pitfall | Correct approach |
+|---------|------------------|
+| Put order/stock logic in controllers | Use `Orders::*`, `Kitchen::*`, `Inventory::*` services. |
+| Broadcast kitchen events ad hoc | Only via `Kitchen::BroadcastOrderItem`. |
+| Treat all order items like dishes | Stock-backed products vs dishes — different states. See [orders-lifecycle.md](./orders-lifecycle.md). |
+| Allow mutations on closed orders | Guard at ability + AASM — items only on `open` orders. |
+
+## Users & auth
+
+| Pitfall | Correct approach |
+|---------|------------------|
+| Allow any user to self-delete | Only org `ADMIN` — see [users-and-platform.md](./users-and-platform.md). |
+| Let org admin assign `SUPER_ADMIN` | Blocked in `UsersController#authorize_assignable_role!`. |
+
+## Operations (ask first)
+
+| Pitfall | Correct approach |
+|---------|------------------|
+| Run `db:migrate` / `db:drop` automatically | **Ask first** — DB may be offline. Document in plan Manual steps. |
+| Commit `.env` or credentials | Never. |
+| Force-push `master` | Never. |
+
+## Process
+
+| Pitfall | Correct approach |
+|---------|------------------|
+| Open PR without updating plan checkboxes | Update `docs/plans/NN-*.md` + README on same branch. |
+| Skip quality gates | Run `bin/ci` or individual checks before push. |
+| Large single commit | Small commits: `feat`, `test`, `docs` per logical change. |

--- a/docs/context/dashboard.md
+++ b/docs/context/dashboard.md
@@ -1,0 +1,65 @@
+# Organization dashboard
+
+Stable reference for analytics endpoints. Plan: [04-organization-dashboard](../plans/04-organization-dashboard.md).
+
+## Endpoints
+
+All require auth + `:read, :dashboard` ability (typically **ADMIN**, **CASH_REGISTER**).
+
+| Method | Path | Params |
+|--------|------|--------|
+| GET | `/api/v1/dashboard/summary` | `from`, `to` (ISO8601 dates) |
+| GET | `/api/v1/dashboard/series` | `from`, `to`, `grain` (default `day`), `metric` (default `revenue`) |
+| GET | `/api/v1/dashboard/kitchen` | `from`, `to` |
+
+Tenant: scoped to `Current.organization` — controller returns **403** if org missing.
+
+## Date ranges
+
+Parsed by `Organizations::Dashboard::RangeParser`:
+
+- Uses **org timezone** (`organization.timezone`) for day boundaries — not server UTC.
+- Max span: **90 days** (`MAX_SPAN_DAYS`).
+- Invalid range → **422** with `code: invalid_range`.
+
+## Services
+
+| Service | Role |
+|---------|------|
+| `Organizations::Dashboard::Summary` | Aggregates for summary card |
+| `Organizations::Dashboard::Series` | Time series (revenue, etc.) |
+| `Organizations::Dashboard::Kitchen` | Kitchen metrics |
+| `Organizations::Dashboard::RangeParser` | Timezone-aware from/to |
+| `Organizations::Dashboard::Cache` | Rails.cache, **3 min TTL** |
+
+Controller stays thin — call services inside `Cache.fetch`.
+
+## Response shape
+
+- Money as **integer cents** + currency field (money-rails pattern).
+- Jbuilder views under `app/views/api/v1/dashboard/`.
+
+## Performance
+
+- DB indexes on `orders`: `(organization_id, created_at)`, `(organization_id, status, created_at)`.
+- Cache key: `dashboard:org:{id}:{kind}:{params...}`.
+
+## Future gating
+
+When [subscription plans](../plans/03-subscription-plans.md) ships, endpoints may check `feature?(:dashboard)`.
+
+## Key files
+
+```
+app/controllers/api/v1/dashboard_controller.rb
+app/services/organizations/dashboard/
+app/models/abilities/base_ability.rb  # dashboard_permissions
+spec/requests/api/v1/dashboard_spec.rb
+```
+
+## AI pitfalls
+
+- Do not query orders without `organization_id` scope.
+- Dashboard dates must respect org timezone — use `RangeParser`, not raw UTC.
+- Do not bypass `Cache` for heavy aggregations without reason.
+- Companion UI plan lives in ubuteco-react — API changes need rswag update.

--- a/docs/context/i18n-and-money.md
+++ b/docs/context/i18n-and-money.md
@@ -1,0 +1,70 @@
+# i18n, locale & money
+
+Stable reference for regional settings. Plan: [02-locale-and-currency](../plans/02-locale-and-currency.md). Decision: [ADR 002](../decisions/002-org-locale-not-user-locale.md).
+
+## Source of truth (v1)
+
+**Organization** columns (not per-user):
+
+| Column | Example | Purpose |
+|--------|---------|---------|
+| `locale` | `pt-BR`, `en`, `es`, `en-CA`, `fr`, `fr-CA` | API error messages, attribute labels |
+| `default_currency` | `BRL`, `USD`, `CAD` | ISO 4217 — money defaults |
+| `timezone` | `America/Sao_Paulo` | Request time zone |
+
+Configured in org settings; **admin-only** PATCH on organization.
+
+## Request-scoped behaviour
+
+`SetOrganizationRegional` on `ApplicationController` (around_action):
+
+```ruby
+I18n.with_locale(org.locale) do
+  Money.with_currency(org.default_currency) do
+    Time.use_zone(org.timezone) { yield }
+  end
+end
+```
+
+- v1: **ignore `Accept-Language`** — org locale only.
+- Fallback: org locale → `I18n.default_locale`.
+
+## Money (money-rails)
+
+- Columns: `*_cents` (integer) + `*_currency` (string).
+- New products: default `price_currency` from org when omitted.
+- New orders: snapshot `total_currency`, line currencies at creation — **historical orders keep frozen currency**.
+- Validation: order line currencies must match order on create.
+
+JSON may expose cents + currency and/or nested money from jbuilder.
+
+## i18n files
+
+| Area | Path |
+|------|------|
+| API error codes | `config/locales/api/{locale}.yml` |
+| Model attribute labels | `config/locales/models/{model}/{locale}.yml` |
+| Available locales | `config/initializers/i18n.rb` |
+
+Structured errors use `field` as machine name; `message` is localized via org locale.
+
+## Dashboard & timestamps
+
+- API serializes timestamps as **ISO8601 UTC**.
+- Dashboard date boundaries use org timezone — see [dashboard.md](./dashboard.md).
+- Front formats display using org settings from API.
+
+## Key files
+
+```
+app/controllers/concerns/set_organization_regional.rb
+app/models/organization.rb
+config/locales/
+```
+
+## AI pitfalls
+
+- Do not hardcode `BRL` or `pt-BR` in new code paths.
+- Do not add per-user locale without revisiting ADR 002.
+- Do not mix currencies on a single order.
+- Error messages: use `render_model_errors` / `render_i18n_api_error`, not hardcoded English strings in controllers.

--- a/docs/context/orders-lifecycle.md
+++ b/docs/context/orders-lifecycle.md
@@ -1,0 +1,80 @@
+# Orders & kitchen lifecycle
+
+Stable reference for order domain behaviour. For implementation history, see [plan 06](../plans/06-order-lifecycle.md). State diagrams: [order-state-diagram.md](../order-state-diagram.md).
+
+## Key models
+
+| Model | Notes |
+|-------|-------|
+| `Order` | AASM states: `open`, `closed`, `payed` |
+| `OrderItem` | AASM states; dish vs non-dish paths differ |
+| `Organization#operational_status` | `open` / `closed` — kitchen shutdown bulk-closes open orders |
+
+## Domain services (use these, don't bypass in controllers)
+
+| Service | When |
+|---------|------|
+| `Orders::AddItem` | Add line to open order (+ stock side effects) |
+| `Orders::UpdateItem` | Update quantity/status with stock adjustment |
+| `Orders::RemoveItem` | Remove line and release stock |
+| `Kitchen::UpdateItemStatus` | Kitchen status transition (org/kitchen guards) |
+| `Kitchen::BroadcastOrderItem` | **Only** AnyCable entry point for kitchen payloads |
+| `Organizations::CloseKitchen` | Bulk-close open orders when org kitchen closes |
+
+Controllers under `app/controllers/api/v1/orders/` and `kitchens_controller.rb` should stay thin — delegate to services.
+
+## Order states
+
+| Transition | Who / trigger |
+|------------|---------------|
+| `open` → `closed` | Staff via `PATCH /api/v1/orders/:id`; **auto** when org kitchen closes |
+| `open` / `closed` → `payed` | Staff with order update permission |
+| `payed` | Terminal — no reopen |
+
+**Guards:** items can only be created/updated/destroyed while order is `open`. Org kitchen **closed** → kitchen API returns empty queue / 403 on status updates.
+
+## Order item — dish (kitchen queue)
+
+- Default status on create: `awaiting`
+- Flow: `awaiting` → `cooking` → `ready` → `with_the_client` (or `canceled`)
+- Kitchen broadcast fires on **create** and **status change** when order and org are both `open`
+- Kitchen role uses `/api/v1/kitchens/:id`; other roles may update via order items API
+
+## Order item — stock-backed products
+
+- Types: `Beer`, `Wine`, `Drink`, `Food` (not `Dish`) — see [inventory-stock.md](./inventory-stock.md)
+- Create reserves stock; destroy releases; quantity change adjusts via `OrderItem#apply_quantity_change!`
+- Statuses `cooking`, `ready`, `empty_stock` are **not** valid on non-dish lines
+
+## API routes
+
+```
+GET/POST   /api/v1/orders
+GET/PATCH/DELETE /api/v1/orders/:id
+GET/POST   /api/v1/orders/:order_id/items
+PATCH/DELETE     /api/v1/orders/:order_id/items/:id
+GET/PATCH  /api/v1/kitchens/:id
+```
+
+## Common errors
+
+| Code | HTTP | When |
+|------|------|------|
+| `validation_error` | 422 | Invalid transition, closed order mutation |
+| `insufficient_stock` | 422 | Stock guard on create/update quantity |
+| `kitchen_closed` | 403 | Kitchen action when org operational status is closed |
+
+Use `render_model_errors` / `render_i18n_api_error` — see [api-conventions.md](./api-conventions.md).
+
+## Testing
+
+- Lifecycle guards: `spec/requests/order_lifecycle_spec.rb`
+- Cross-tenant: `spec/security/cross_tenant/orders_create_spec.rb`, `access_spec.rb`
+- Stock concurrency: `spec/models/stock_reservation_spec.rb`
+
+## AI pitfalls
+
+- Do not add items to a `closed` or `payed` order.
+- Do not broadcast kitchen events outside `Kitchen::BroadcastOrderItem`.
+- Do not skip stock hooks on stockable products.
+- Dish items use kitchen queue; drinks/food use stock path — different state machines.

--- a/docs/context/search-and-opensearch.md
+++ b/docs/context/search-and-opensearch.md
@@ -1,0 +1,83 @@
+# Search & OpenSearch
+
+Stable reference for Searchkick full-text search. Plan: [07-search-operations](../plans/07-search-operations.md). Operations: [search-operations-runbook.md](../search-operations-runbook.md).
+
+## Indexed models
+
+Searchkick on (all include `organization_id` in `search_data` where tenant-scoped):
+
+- `User`, `Order`, `Organization`
+- Catalog: `Beer`, `Wine`, `Drink`, `Food`, `Dish`, `Maker`
+
+Config: `callbacks: :async` → Sidekiq **`searchkick`** queue (`config/initializers/searchkick.rb`, `config/sidekiq.yml`).
+
+## Read path (controllers)
+
+- Use `pagy_search_authorized(Model)` from `SearchkickAuthorizable` — merges CanCan conditions into OpenSearch `where` filter.
+- **Never** run unscoped `Model.search` in org-facing controllers.
+- OpenSearch down → `SearchUnavailableError` → **503** `search_unavailable` (no silent empty results).
+
+```ruby
+@pagy, @records = pagy_search_authorized(User)
+@pagy, @records = pagy_search_authorized(Beer, extra_where: { active: true })
+```
+
+## Write path (indexing)
+
+| Trigger | Mechanism |
+|---------|-----------|
+| Record create/update/destroy | Searchkick async callback → `searchkick` queue |
+| New catalog product create | Extra sync `reindex(refresh: true)` via `ImmediateSearchkickIndexing` |
+| Maintenance | Rake tasks or `ReindexJob` |
+
+**Do not** add org-wide `after_commit` reindex on every model change — use per-record async indexing.
+
+## ReindexJob (`app/sidekiq/reindex_job.rb`)
+
+| Args | Behaviour |
+|------|-----------|
+| `model_name`, `record_id` | Single-record reindex |
+| `model_name`, `nil`, `organization_id` | Org-scoped batch via `reindex_for_organization` |
+| Neither id nor org | **Refused** — use rake with env guard |
+
+Sets `Current.organization` during org-scoped reindex; calls `Current.reset` in `ensure`.
+
+## Rake tasks
+
+```bash
+bin/rails searchkick:reindex:model[Beer]
+bin/rails searchkick:reindex:organization[ORG_ID]
+ALLOW_FULL_SEARCH_REINDEX=1 bin/rails searchkick:reindex:all   # staging/maintenance only
+```
+
+## Environment
+
+| Variable | Purpose |
+|----------|---------|
+| `OPENSEARCH_URL` | Cluster URL |
+| `SEARCHKICK_INDEX_PREFIX` | Per-env index prefix (staging vs production) |
+| `ALLOW_FULL_SEARCH_REINDEX` | Must be `1` for full reindex |
+
+## Key files
+
+```
+app/controllers/concerns/searchkick_authorizable.rb
+app/sidekiq/reindex_job.rb
+app/services/searchkick_reindex.rb
+lib/tasks/searchkick_reindex.rake
+spec/support/searchkick.rb
+spec/security/cross_tenant/search_spec.rb
+```
+
+## Testing
+
+- Specs: `Searchkick.callbacks(:inline)` in `spec/support/searchkick.rb`
+- Cross-tenant: `spec/security/cross_tenant/search_spec.rb`
+- Unavailable: `spec/requests/search_unavailable_spec.rb`
+
+## AI pitfalls
+
+- Do not search without org filter — always `pagy_search_authorized`.
+- Do not trigger full-class reindex in application code.
+- Jobs that reindex must set `Current` or pass `organization_id` to `ReindexJob`.
+- After changing `search_data` fields, document reindex in plan Manual steps.

--- a/docs/context/testing.md
+++ b/docs/context/testing.md
@@ -1,0 +1,112 @@
+# Testing patterns — API
+
+How to add and run specs in ubuteco_api. CI runs the same suite as local `bundle exec rspec` (see [workflow-plans-and-git.md](../workflow-plans-and-git.md)).
+
+## Run commands
+
+```bash
+bundle exec rspec                              # full suite
+bundle exec rspec spec/requests/order_lifecycle_spec.rb
+bundle exec rspec spec/security/cross_tenant/
+bin/ci                                         # RuboCop + Brakeman + bundler-audit + RSpec + OpenAPI drift
+```
+
+Requires Postgres (and OpenSearch for Searchkick specs). See [dev-setup.md](../dev-setup.md).
+
+## Spec layout
+
+| Directory | Purpose |
+|-----------|---------|
+| `spec/requests/` | HTTP integration (preferred for API behaviour) |
+| `spec/requests/api/v1/*_spec.rb` | rswag specs — generate OpenAPI |
+| `spec/controllers/api/v1/` | Controller/request specs (legacy patterns) |
+| `spec/models/` | Model validations, AASM, stock logic |
+| `spec/services/` | Service object unit tests |
+| `spec/security/cross_tenant/` | **Required** for tenant-scoped resources |
+| `spec/support/` | Helpers, Searchkick, Sidekiq, SimpleCov |
+
+## Auth helpers
+
+Included via `spec/support/helpers/headers.rb`:
+
+```ruby
+get api_v1_order_path(order), headers: auth_header(user)
+post path, params: body.to_json, headers: auth_header(admin)
+```
+
+Factories: `spec/factories/` — traits like `:waiter`, `:kitchen`, `:open` on orders.
+
+Role factories create users with correct `organization_id` — use separate orgs for cross-tenant tests.
+
+## Request spec pattern
+
+Mirror an existing file in the same area:
+
+```ruby
+require "rails_helper"
+
+RSpec.describe "Feature name", type: :request do
+  let(:organization) { create(:organization) }
+  let(:admin) { organization.user }
+
+  it "returns structured errors on validation failure" do
+    post api_v1_users_path,
+         params: { email: nil }.to_json,
+         headers: auth_header(admin)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body["errors"].first).to include("code" => "validation_error")
+  end
+end
+```
+
+## Cross-tenant specs (mandatory for new org-scoped resources)
+
+For every new tenant-owned resource, add cases to `spec/security/cross_tenant/`:
+
+- User from org A must **not** show/update/destroy org B record by ID → `403`
+- Create must not attach to another org via param injection
+
+Existing coverage: `access_spec.rb`, `orders_create_spec.rb`, `search_spec.rb`.
+
+## rswag / OpenAPI
+
+Canonical flow:
+
+1. Add or extend `spec/requests/api/v1/<resource>_spec.rb` with `require 'swagger_helper'`
+2. Document paths, parameters, and `schema '$ref' => '#/components/schemas/errors_response'` for 422
+3. Regenerate: `bundle exec rake openapi:refresh` (or `rswag:specs:swaggerize` + `openapi:sync_docs`)
+4. Verify: `bundle exec rake openapi:drift_check`
+
+Schemas live in `spec/swagger_helper.rb`. Committed artifacts: `swagger/v1/swagger.yaml`, `docs/swagger.yaml`.
+
+**After any API contract change:** update rswag spec + run drift check before PR.
+
+## Searchkick
+
+- Test support: `spec/support/searchkick.rb` — callbacks inline in tests
+- Cross-tenant search: `spec/security/cross_tenant/search_spec.rb`
+- Search unavailable: `spec/requests/search_unavailable_spec.rb`
+
+## Structured error assertions
+
+Prefer asserting `code` and optional `field`:
+
+```ruby
+expect(response.parsed_body.dig("errors", 0, "code")).to eq("account_deletion_forbidden")
+```
+
+Not bare string arrays — legacy format is migrated.
+
+## Coverage
+
+SimpleCov via `spec/support/simplecov.rb`. Codecov in CI — avoid dropping coverage on changed areas without reason.
+
+## AI checklist for new features
+
+- [ ] Request spec for happy path + main failure
+- [ ] Cross-tenant case if org-scoped
+- [ ] Service spec if non-trivial domain logic
+- [ ] rswag update if public API contract changed
+- [ ] `openapi:drift_check` passes
+- [ ] Mirror patterns from nearest existing spec file

--- a/docs/context/users-and-platform.md
+++ b/docs/context/users-and-platform.md
@@ -1,0 +1,80 @@
+# Users, roles & platform admin
+
+Stable reference for user management and super-admin platform routes. Plans: [10-users-admin-api](../plans/10-users-admin-api.md), [01-multi-tenant](../plans/01-multi-tenant.md). Role summary: [roles-and-access.md](./roles-and-access.md).
+
+## Org-scoped users (`/api/v1/users`)
+
+| Action | Who |
+|--------|-----|
+| CRUD staff in org | `ADMIN` (via `can :manage, User, organization_id:`) |
+| Read/update own profile | All roles (except customer namespace rules) |
+| Self-delete (`DELETE /users/:id` where `id == current_user`) | **`ADMIN` only** |
+| Assign `SUPER_ADMIN` role | **Forbidden** — `role_assignment_forbidden` (403) |
+
+### Self-delete policy
+
+Enforced in **abilities + CanCan**, not only UI:
+
+- `Abilities::BaseAbility#can_manage_self` — `can :destroy, User, id: user.id` only when `org_admin?(user)`
+- `SuperAdminAbility` — `cannot :destroy, User, id: user.id` (super admin cannot delete self)
+- Kitchen, waiter, cash register, customer — no self-delete
+- On denied self-delete: `ApplicationController#account_deletion_denied?` → `account_deletion_forbidden` (403, structured JSON)
+
+Org admin may delete **other** staff in the same org via `:manage` on `UsersController`.
+
+### Role assignment guard
+
+`UsersController#authorize_assignable_role!` blocks assigning `SUPER_ADMIN` on create/update — returns `role_assignment_forbidden`.
+
+## Platform routes (`SUPER_ADMIN` only)
+
+Namespace: `/api/v1/platform/...`
+
+| Controller | Purpose |
+|------------|---------|
+| `Api::V1::Platform::OrganizationsController` | Cross-org org CRUD |
+| `Api::V1::Platform::Organizations::UsersController` | Users within a platform-selected org |
+
+`SuperAdminAbility::PLATFORM_CONTROLLERS` gates full platform `:manage` permissions. Outside platform controllers, super admin has global read/manage on catalog entities (beer/wine styles) but **operational catalog mutation is restricted** — read-only platform mode for menu entities in org context.
+
+## Tenant rules (always)
+
+- Org-scoped users must have `organization_id` set.
+- **Never** accept client `organization_id` on create when `Current.organization` should define tenant — `UsersController#create_params` merges `organization_id: current_user.organization_id`.
+- Cross-org access by ID → 403 — see `spec/security/cross_tenant/access_spec.rb`.
+
+## Soft delete
+
+`User` uses Paranoia (`acts_as_paranoid`). Destroy is soft delete.
+
+## Common errors
+
+| Code | HTTP | When |
+|------|------|------|
+| `account_deletion_forbidden` | 403 | Non-admin self-delete attempt |
+| `role_assignment_forbidden` | 403 | Assigning `SUPER_ADMIN` |
+| `validation_error` | 422 | Model validation failures |
+
+## Key files
+
+```
+app/controllers/api/v1/users_controller.rb
+app/controllers/api/v1/platform/
+app/models/abilities/admin_ability.rb
+app/models/abilities/super_admin_ability.rb
+app/models/abilities/base_ability.rb
+app/controllers/application_controller.rb  # account_deletion_denied?
+```
+
+## Testing
+
+- Self-delete / role guard: `spec/controllers/api/v1/users_request_spec.rb`
+- Cross-tenant users: `spec/security/cross_tenant/access_spec.rb`
+- Platform: `spec/requests/api/v1/platform/organizations_spec.rb`
+
+## AI pitfalls
+
+- Do not allow kitchen/waiter self-delete — policy is API-enforced.
+- Do not let org admin assign `SUPER_ADMIN`.
+- Do not trust `organization_id` from request body on user create.
+- Platform routes are not org-scoped the same way — check `SuperAdminAbility` and controller namespace before adding endpoints.

--- a/docs/decisions/004-structured-api-errors.md
+++ b/docs/decisions/004-structured-api-errors.md
@@ -1,0 +1,44 @@
+# ADR 004: Structured API error responses
+
+**Status:** Accepted  
+**Date:** 2026 (documented from plan 05 / #39)
+
+## Context
+
+Clients and the React frontend need stable error handling. Legacy responses used bare JSON string arrays (`errors.full_messages`), which are hard to map to fields and i18n.
+
+## Decision
+
+All v1 API controllers use **`ApiErrorRenderable`** (included on `ApplicationController`):
+
+```json
+{
+  "errors": [
+    {
+      "code": "validation_error",
+      "field": "email",
+      "message": "Email has already been taken"
+    }
+  ]
+}
+```
+
+- `render_model_errors(record)` — ActiveRecord validation failures (`code: validation_error`)
+- `render_api_errors([{ code:, field:, message: }])` — domain errors
+- `render_i18n_api_error(code, status:, **options)` — localized messages from `config/locales/api/*.yml`
+
+Known codes include: `validation_error`, `insufficient_stock`, `kitchen_closed`, `account_deletion_forbidden`, `role_assignment_forbidden`, `rate_limit_exceeded`, `search_unavailable`, `error` (fallback).
+
+Legacy string-array responses are **not** added to new code.
+
+## Consequences
+
+- rswag uses `#/components/schemas/errors_response` for 422/403 error examples.
+- OpenAPI and frontend can key off `code` and optional `field`.
+- Migration of any remaining legacy renders is tracked in [plan 05](../plans/05-platform-hardening.md).
+
+## References
+
+- `app/controllers/concerns/api_error_renderable.rb`
+- [docs/context/api-conventions.md](../context/api-conventions.md)
+- [docs/plans/api-conventions.md](../plans/api-conventions.md) (auth, CORS, rate limits)

--- a/docs/decisions/005-openapi-as-contract-source.md
+++ b/docs/decisions/005-openapi-as-contract-source.md
@@ -1,0 +1,29 @@
+# ADR 005: OpenAPI (rswag) as contract source of truth
+
+**Status:** Accepted  
+**Date:** 2026 (documented from plan 08)
+
+## Context
+
+AI-assisted development and the React frontend both need a reliable API contract. Undocumented controller changes cause drift and broken clients.
+
+## Decision
+
+- **Canonical spec:** `swagger/v1/swagger.yaml`, generated from rswag request specs.
+- **Published copy:** `docs/swagger.yaml` synced for GitHub Pages Swagger UI.
+- **CI enforcement:** `rake openapi:drift_check` fails if committed YAML differs after regenerate.
+- **Workflow:** after contract changes → update `spec/requests/api/v1/*_spec.rb` → `rake openapi:refresh` → commit both YAML files.
+
+Agents and humans must check existing routes/spec before inventing endpoints.
+
+## Consequences
+
+- New public endpoints require rswag coverage (or explicit plan exception).
+- `bin/ci` includes OpenAPI drift check.
+- Release process references synced spec — see [release-process.md](../release-process.md).
+
+## References
+
+- [docs/plans/08-api-contract-and-ci.md](../plans/08-api-contract-and-ci.md)
+- [docs/context/api-conventions.md](../context/api-conventions.md)
+- `lib/tasks/openapi.rake`, `spec/swagger_helper.rb`

--- a/docs/decisions/006-jobs-and-current-tenant.md
+++ b/docs/decisions/006-jobs-and-current-tenant.md
@@ -1,0 +1,34 @@
+# ADR 006: Jobs and console must set tenant context explicitly
+
+**Status:** Accepted  
+**Date:** 2026
+
+## Context
+
+uButeco uses shared-schema multi-tenant with request-scoped `Current.user` / `Current.organization` (`ActiveSupport::CurrentAttributes`). HTTP requests set `Current` via `SetCurrentTenant`. Sidekiq jobs and Rails console have **no automatic tenant**.
+
+Agents often assume `Current.organization` is always available in background code.
+
+## Decision
+
+- **`Current` is request-scoped only** — set in `SetCurrentTenant` after auth; cleared after each request.
+- **Sidekiq jobs** must either:
+  - pass `organization_id` as an argument and set `Current.organization` at job start, or
+  - scope all queries explicitly by `organization_id` without relying on `Current`.
+- **Always** call `Current.reset` in job `ensure` when setting `Current` in a job.
+- **Console / one-off scripts** — set `Current` manually or pass IDs explicitly; never assume tenant from a previous request.
+
+Example: `ReindexJob` sets `Current.organization` for org-scoped reindex and resets in `ensure`.
+
+## Consequences
+
+- New jobs that touch tenant data must document required args in plan Manual steps.
+- Code that reads `Current.organization` outside HTTP must verify context is set.
+- AnyCable/Sidekiq kitchen broadcasts must pass org context in job args or channel subscription, not assume `Current` from enqueue time unless captured.
+
+## References
+
+- `app/models/current.rb`
+- `app/controllers/concerns/set_current_tenant.rb`
+- `app/sidekiq/reindex_job.rb`
+- [architecture.md](../context/architecture.md)

--- a/docs/order-state-diagram.md
+++ b/docs/order-state-diagram.md
@@ -1,6 +1,6 @@
 # Order lifecycle — state diagrams
 
-Companion to [plan 06](./plans/06-order-lifecycle.md). Describes **current intended behaviour** after domain hardening.
+Companion to [plan 06](./plans/06-order-lifecycle.md) and [orders-lifecycle context](./context/orders-lifecycle.md). Describes **current intended behaviour** after domain hardening.
 
 ---
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -67,5 +67,6 @@ When starting a plan, update its header `Status:` and check boxes as you go. Use
 | [context/](../context/) | Architecture, roles, API conventions, domain docs |
 | [context/common-ai-pitfalls.md](../context/common-ai-pitfalls.md) | Frequent agent mistakes |
 | [context/testing.md](../context/testing.md) | RSpec, rswag, cross-tenant patterns |
+| [backlog/](../backlog/) | Small API fixes (promote to plan if scope grows) |
 | [decisions/](../decisions/) | ADRs (permanent decisions) |
 | [dev-setup.md](../dev-setup.md) | Ports, docker, migrations |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -64,6 +64,8 @@ When starting a plan, update its header `Status:` and check boxes as you go. Use
 
 | Doc | Purpose |
 |-----|---------|
-| [context/](../context/) | Architecture, roles, API conventions |
+| [context/](../context/) | Architecture, roles, API conventions, domain docs |
+| [context/common-ai-pitfalls.md](../context/common-ai-pitfalls.md) | Frequent agent mistakes |
+| [context/testing.md](../context/testing.md) | RSpec, rswag, cross-tenant patterns |
 | [decisions/](../decisions/) | ADRs (permanent decisions) |
 | [dev-setup.md](../dev-setup.md) | Ports, docker, migrations |

--- a/docs/plans/api-conventions.md
+++ b/docs/plans/api-conventions.md
@@ -2,47 +2,15 @@
 
 **Status:** in progress (plan [05-platform-hardening](./05-platform-hardening.md))
 
+> **Stable reference:** error format, Swagger workflow, and request patterns live in [docs/context/api-conventions.md](../context/api-conventions.md), [ADR 004](../decisions/004-structured-api-errors.md), and [ADR 005](../decisions/005-openapi-as-contract-source.md). This file tracks hardening items still in flight.
+
 ---
 
 ## Error responses
 
-Prefer structured JSON over bare string arrays:
+See [context/api-conventions.md](../context/api-conventions.md#error-responses) and [ADR 004](../decisions/004-structured-api-errors.md).
 
-```json
-{
-  "errors": [
-    {
-      "code": "validation_error",
-      "field": "email",
-      "message": "Email has already been taken"
-    }
-  ]
-}
-```
-
-### Codes (initial set)
-
-| Code | HTTP | When |
-|------|------|------|
-| `validation_error` | 422 | ActiveRecord / model validation |
-| `insufficient_stock` | 422 | Order item stock guard |
-| `rate_limit_exceeded` | 429 | Rack::Attack throttle |
-| `error` | varies | Generic fallback during migration |
-
-### Controllers
-
-Include `ApiErrorRenderable` and use:
-
-- `render_model_errors(record)` — validation failures
-- `render_api_errors([{ code:, field:, message: }])` — domain errors
-
-Legacy `render json: model.errors.full_messages` is migrated gradually.
-
-### Locale
-
-Validation `message` strings use the organization locale via `SetOrganizationRegional` (`I18n.with_locale`). Attribute labels live under `config/locales/models/{model}/{locale}.yml` (`activerecord.attributes.{model}.{field}`). The `field` key in each error is the machine name (e.g. `beer_style`) for client-side mapping.
-
----
+Legacy `render json: model.errors.full_messages` is migrated gradually (plan 05).
 
 ## Auth (JWT)
 

--- a/docs/search-operations-runbook.md
+++ b/docs/search-operations-runbook.md
@@ -1,6 +1,6 @@
 # OpenSearch / Searchkick runbook
 
-Operations guide for **ubuteco_api** search. See also [plan 07](./plans/07-search-operations.md).
+Operations guide for **ubuteco_api** search. Context: [search-and-opensearch.md](./context/search-and-opensearch.md). Plan: [07-search-operations.md](./plans/07-search-operations.md).
 
 ## Dev stack
 

--- a/docs/workflow-plans-and-git.md
+++ b/docs/workflow-plans-and-git.md
@@ -60,6 +60,7 @@ Run locally on the feature branch — **must pass** before `git push` / `gh pr c
 | **Brakeman** | `bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error` |
 | **bundler-audit** | `bin/bundler-audit check --update` |
 | **OpenAPI drift** (if API contract changed) | `bundle exec rake openapi:drift_check` |
+| **Plan status drift** (if plan docs changed) | `bin/plans_drift_check` |
 
 **Shortcut:** `bin/ci` runs RuboCop, Brakeman, bundler-audit, RSpec, and OpenAPI drift (plus seeds). Requires local Postgres and env vars — see [dev-setup.md](./dev-setup.md).
 


### PR DESCRIPTION
## Summary

- Expand AI onboarding for ubuteco_api: domain context docs (orders, users, inventory, search, dashboard, i18n), testing guide, and common pitfalls
- Add ADRs 004–006 (structured errors, OpenAPI contract, jobs/Current tenant)
- Add Cursor scoped rules (tenant-safety, openapi-contract) mirroring stable docs
- Add `bin/plans_drift_check` and wire it into `bin/ci` and GitHub Actions
- Add agent entry points for Claude (`CLAUDE.md`) and Copilot (`.github/copilot-instructions.md`)
- Add API backlog template (`docs/backlog/`)

## Test plan

- [x] `bin/plans_drift_check` passes locally
- [ ] CI green (plan drift + existing gates)
- [ ] Spot-check `AGENTS.md` links resolve

No application code changes — documentation and CI doc checks only.


Made with [Cursor](https://cursor.com)